### PR TITLE
Fix auto-update for Miners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,6 @@ fabric.properties
 
 # Validators db.
 database.db
+
+# PerfInfo generated app
+neurons/Miner/app


### PR DESCRIPTION
fix git status for the auto-update by ignoring useless file

![image](https://github.com/neuralinternet/compute-subnet/assets/69808183/495c8f80-382f-4275-8172-6f3b237fead8)
