### PR TITLE
fix: minimal difficulty setup to 1.

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.3.6"
+__version__ = "1.3.7"
 __minimal_miner_version__ = "1.3.6"
-__minimal_validator_version__ = "1.3.5"
+__minimal_validator_version__ = "1.3.7"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -20,7 +20,7 @@ import string
 # Define the version of the template module.
 __version__ = "1.3.7"
 __minimal_miner_version__ = "1.3.6"
-__minimal_validator_version__ = "1.3.7"
+__minimal_validator_version__ = "1.3.6"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -311,13 +311,11 @@ class Validator:
             last_20_challenge_failed = force_to_float_or_default(stat.get("last_20_challenge_failed"))
             challenge_successes = force_to_float_or_default(stat.get("challenge_successes"))
             if challenge_successes >= 20:
-                difficulty = (
-                    current_difficulty + 1
-                    if last_20_challenge_failed == 0
-                    else current_difficulty - 1
-                    if last_20_challenge_failed >= 2
-                    else current_difficulty
-                )
+                if last_20_challenge_failed == 0:
+                    difficulty = current_difficulty + 1
+                elif last_20_challenge_failed > 2:
+                    current_difficulty - 1
+                difficulty = max(current_difficulty, 1)
         except KeyError:
             pass
         except Exception as e:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -314,7 +314,9 @@ class Validator:
                 if last_20_challenge_failed == 0:
                     difficulty = current_difficulty + 1
                 elif last_20_challenge_failed > 2:
-                    current_difficulty - 1
+                    difficulty = current_difficulty - 1
+                else:
+                    difficulty = current_difficulty
         except KeyError:
             pass
         except Exception as e:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -315,12 +315,11 @@ class Validator:
                     difficulty = current_difficulty + 1
                 elif last_20_challenge_failed > 2:
                     current_difficulty - 1
-                difficulty = max(current_difficulty, 1)
         except KeyError:
             pass
         except Exception as e:
             bt.logging.error(f"{e} => difficulty minimal: {pow_min_difficulty} attributed for {uid}")
-        return difficulty
+        return max(difficulty, 1)
 
 
     @staticmethod


### PR DESCRIPTION
I have detected a potential issue where the difficulty can go < 0 if a miner keeps failing.
Initially I made the algorithm assuming difficulty will never go under 0, and I forgot to put the limit.
I have not started the full bench of test with the score if it happens, so I do not know the exact impact.

In theory it is ok and not critical. In practice, I do the PR.

Please merge only if you observe issues with the minimal difficulty going < 0.