### PR TITLE
Integration with sentry.io

### DIFF
--- a/compute/prometheus.py
+++ b/compute/prometheus.py
@@ -17,8 +17,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import sentry_sdk
-import sentry_sdk
+
+
 import bittensor
 import bittensor.utils.networking as net
 
@@ -67,8 +67,8 @@ def prometheus_extrinsic(
             external_ip = net.get_external_ip()
             bittensor.logging.trace("Found external ip: {}".format(external_ip))
         except Exception as E:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             raise RuntimeError("Unable to attain your external ip. Check your internet connection. error: {}".format(E)) from E
     else:
         external_ip = ip

--- a/compute/prometheus.py
+++ b/compute/prometheus.py
@@ -17,6 +17,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import sentry_sdk
+import sentry_sdk
 import bittensor
 import bittensor.utils.networking as net
 
@@ -65,6 +67,8 @@ def prometheus_extrinsic(
             external_ip = net.get_external_ip()
             bittensor.logging.trace("Found external ip: {}".format(external_ip))
         except Exception as E:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             raise RuntimeError("Unable to attain your external ip. Check your internet connection. error: {}".format(E)) from E
     else:
         external_ip = ip

--- a/compute/prometheus.py
+++ b/compute/prometheus.py
@@ -19,6 +19,7 @@
 
 
 
+import sentry_sdk
 import bittensor
 import bittensor.utils.networking as net
 
@@ -67,6 +68,7 @@ def prometheus_extrinsic(
             external_ip = net.get_external_ip()
             bittensor.logging.trace("Found external ip: {}".format(external_ip))
         except Exception as E:
+            sentry_sdk.capture_exception()
             
             
             raise RuntimeError("Unable to attain your external ip. Check your internet connection. error: {}".format(E)) from E

--- a/compute/utils/db.py
+++ b/compute/utils/db.py
@@ -1,7 +1,7 @@
 import sqlite3
 
-import sentry_sdk
-import sentry_sdk
+
+
 import bittensor as bt
 
 
@@ -44,8 +44,8 @@ class ComputeDb:
 
             self.conn.commit()
         except Exception as e:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             self.conn.rollback()
             bt.logging.error(f"ComputeDb error: {e}")
         finally:

--- a/compute/utils/db.py
+++ b/compute/utils/db.py
@@ -1,5 +1,7 @@
 import sqlite3
 
+import sentry_sdk
+import sentry_sdk
 import bittensor as bt
 
 
@@ -42,6 +44,8 @@ class ComputeDb:
 
             self.conn.commit()
         except Exception as e:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             self.conn.rollback()
             bt.logging.error(f"ComputeDb error: {e}")
         finally:

--- a/compute/utils/db.py
+++ b/compute/utils/db.py
@@ -2,6 +2,7 @@ import sqlite3
 
 
 
+import sentry_sdk
 import bittensor as bt
 
 
@@ -44,6 +45,7 @@ class ComputeDb:
 
             self.conn.commit()
         except Exception as e:
+            sentry_sdk.capture_exception()
             
             
             self.conn.rollback()

--- a/compute/utils/math.py
+++ b/compute/utils/math.py
@@ -1,3 +1,4 @@
+import sentry_sdk
 
 
 __all__ = ["percent", "percent_yield", "force_to_float_or_default"]
@@ -19,6 +20,7 @@ def force_to_float_or_default(a, default=0.0):
     try:
         return float(a)
     except Exception:
+        sentry_sdk.capture_exception()
         
         
         return default

--- a/compute/utils/math.py
+++ b/compute/utils/math.py
@@ -1,3 +1,5 @@
+import sentry_sdk
+import sentry_sdk
 __all__ = ["percent", "percent_yield", "force_to_float_or_default"]
 
 
@@ -17,4 +19,6 @@ def force_to_float_or_default(a, default=0.0):
     try:
         return float(a)
     except Exception:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return default

--- a/compute/utils/math.py
+++ b/compute/utils/math.py
@@ -1,5 +1,5 @@
-import sentry_sdk
-import sentry_sdk
+
+
 __all__ = ["percent", "percent_yield", "force_to_float_or_default"]
 
 
@@ -19,6 +19,6 @@ def force_to_float_or_default(a, default=0.0):
     try:
         return float(a)
     except Exception:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return default

--- a/compute/utils/parser.py
+++ b/compute/utils/parser.py
@@ -56,6 +56,13 @@ class ComputeArgPaser(argparse.ArgumentParser):
             default=[],
         )
 
+        self.add_argument(
+            "--sentry-dsn",
+            type=str,
+            default=None,
+            help="The url that sentry will use to send exception information to"
+        )
+
         self.add_validator_argument()
         self.add_miner_argument()
 

--- a/compute/utils/sentry.py
+++ b/compute/utils/sentry.py
@@ -1,6 +1,6 @@
 from bittensor import config as Config
 import bittensor as bt
-import sentry_sdk
+
 from compute import __version__
 
 def init_sentry(config : Config, tags : dict = {}):

--- a/compute/utils/sentry.py
+++ b/compute/utils/sentry.py
@@ -1,5 +1,6 @@
 from bittensor import config as Config
 import bittensor as bt
+import sentry_sdk
 
 from compute import __version__
 

--- a/compute/utils/sentry.py
+++ b/compute/utils/sentry.py
@@ -1,0 +1,22 @@
+from bittensor import config as Config
+import bittensor as bt
+import sentry_sdk
+from compute import __version__
+
+def init_sentry(config : Config, tags : dict = {}):
+    if config.sentry_dsn is None:
+        bt.logging.info(f"Sentry is DISABLED")
+        return
+
+    bt.logging.info(f"Sentry is ENABLED. Using dsn={config.sentry_dsn}")
+    sentry_sdk.init(
+        dsn=config.sentry_dsn,
+        release=__version__,
+        traces_sample_rate=1.0,
+        profiles_sample_rate=1.0
+    )
+
+    sentry_sdk.set_tag("netuid", config.netuid)
+
+    for key, value in tags.items():
+        sentry_sdk.set_tag(key, value)

--- a/compute/utils/version.py
+++ b/compute/utils/version.py
@@ -16,8 +16,8 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABI
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
-import sentry_sdk
-import sentry_sdk
+
+
 import codecs
 import os
 import re
@@ -43,8 +43,8 @@ def version2number(version: str):
             version = version.split(".")
             return (100 * int(version[0])) + (10 * int(version[1])) + (1 * int(version[2]))
     except Exception as _:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         pass
     return None
 
@@ -64,13 +64,13 @@ def get_remote_version(pattern: str = "__version__"):
             print("Failed to get file content with status code:", response.status_code)
             return None
     except requests.exceptions.Timeout:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         print("The request timed out after 30 seconds.")
         return None
     except requests.exceptions.RequestException as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         print("There was an error while handling the request:", e)
         return None
 
@@ -85,8 +85,8 @@ def get_local_version():
             version_string = version_match.group(1)
         return version_string
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"Error getting local version. : {e}")
         return ""
 
@@ -118,14 +118,14 @@ def update_repo():
             bt.logging.info("pulling success")
             return True
         except git.exc.GitCommandError as e:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             bt.logging.info(f"update : Merge conflict detected: {e} Recommend you manually commit changes and update")
             return handle_merge_conflict(repo)
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"update failed: {e} Recommend you manually commit changes and update")
 
     return False
@@ -147,8 +147,8 @@ def handle_merge_conflict(repo):
         bt.logging.info(f"✅ Repo update success")
         return True
     except git.GitCommandError as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"update failed: {e} Recommend you manually commit changes and update")
         return False
 
@@ -183,8 +183,8 @@ def try_update_packages(force=False):
         bt.logging.info("📦Updating packages finished.")
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         if not force:
             try_update_packages(force=True)
         bt.logging.info(f"Updating packages failed {e}")
@@ -198,8 +198,8 @@ def try_update():
                 try_update_packages()
                 restart_app()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.info(f"Try updating failed {e}")
 
 
@@ -210,8 +210,8 @@ def check_hashcat_version(hashcat_path: str = "hashcat"):
             bt.logging.info(f"Version of hashcat found: {process.stdout.decode()}".strip("\n"))
         return True
     except subprocess.CalledProcessError:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(
             f"Hashcat is not available nor installed on the machine. Please make sure hashcat is available in your PATH or give the explicit location using the following argument: --miner.hashcat.path"
         )

--- a/compute/utils/version.py
+++ b/compute/utils/version.py
@@ -18,6 +18,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 
+import sentry_sdk
 import codecs
 import os
 import re
@@ -43,6 +44,7 @@ def version2number(version: str):
             version = version.split(".")
             return (100 * int(version[0])) + (10 * int(version[1])) + (1 * int(version[2]))
     except Exception as _:
+        sentry_sdk.capture_exception()
         
         
         pass
@@ -64,11 +66,13 @@ def get_remote_version(pattern: str = "__version__"):
             print("Failed to get file content with status code:", response.status_code)
             return None
     except requests.exceptions.Timeout:
+        sentry_sdk.capture_exception()
         
         
         print("The request timed out after 30 seconds.")
         return None
     except requests.exceptions.RequestException as e:
+        sentry_sdk.capture_exception()
         
         
         print("There was an error while handling the request:", e)
@@ -85,6 +89,7 @@ def get_local_version():
             version_string = version_match.group(1)
         return version_string
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"Error getting local version. : {e}")
@@ -118,12 +123,14 @@ def update_repo():
             bt.logging.info("pulling success")
             return True
         except git.exc.GitCommandError as e:
+            sentry_sdk.capture_exception()
             
             
             bt.logging.info(f"update : Merge conflict detected: {e} Recommend you manually commit changes and update")
             return handle_merge_conflict(repo)
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"update failed: {e} Recommend you manually commit changes and update")
@@ -147,6 +154,7 @@ def handle_merge_conflict(repo):
         bt.logging.info(f"✅ Repo update success")
         return True
     except git.GitCommandError as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"update failed: {e} Recommend you manually commit changes and update")
@@ -183,6 +191,7 @@ def try_update_packages(force=False):
         bt.logging.info("📦Updating packages finished.")
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         if not force:
@@ -198,6 +207,7 @@ def try_update():
                 try_update_packages()
                 restart_app()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.info(f"Try updating failed {e}")
@@ -210,6 +220,7 @@ def check_hashcat_version(hashcat_path: str = "hashcat"):
             bt.logging.info(f"Version of hashcat found: {process.stdout.decode()}".strip("\n"))
         return True
     except subprocess.CalledProcessError:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(

--- a/compute/utils/version.py
+++ b/compute/utils/version.py
@@ -16,6 +16,8 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABI
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 """
+import sentry_sdk
+import sentry_sdk
 import codecs
 import os
 import re
@@ -41,6 +43,8 @@ def version2number(version: str):
             version = version.split(".")
             return (100 * int(version[0])) + (10 * int(version[1])) + (1 * int(version[2]))
     except Exception as _:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         pass
     return None
 
@@ -60,9 +64,13 @@ def get_remote_version(pattern: str = "__version__"):
             print("Failed to get file content with status code:", response.status_code)
             return None
     except requests.exceptions.Timeout:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         print("The request timed out after 30 seconds.")
         return None
     except requests.exceptions.RequestException as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         print("There was an error while handling the request:", e)
         return None
 
@@ -77,6 +85,8 @@ def get_local_version():
             version_string = version_match.group(1)
         return version_string
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error getting local version. : {e}")
         return ""
 
@@ -108,10 +118,14 @@ def update_repo():
             bt.logging.info("pulling success")
             return True
         except git.exc.GitCommandError as e:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             bt.logging.info(f"update : Merge conflict detected: {e} Recommend you manually commit changes and update")
             return handle_merge_conflict(repo)
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"update failed: {e} Recommend you manually commit changes and update")
 
     return False
@@ -133,6 +147,8 @@ def handle_merge_conflict(repo):
         bt.logging.info(f"✅ Repo update success")
         return True
     except git.GitCommandError as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"update failed: {e} Recommend you manually commit changes and update")
         return False
 
@@ -167,6 +183,8 @@ def try_update_packages(force=False):
         bt.logging.info("📦Updating packages finished.")
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         if not force:
             try_update_packages(force=True)
         bt.logging.info(f"Updating packages failed {e}")
@@ -180,6 +198,8 @@ def try_update():
                 try_update_packages()
                 restart_app()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Try updating failed {e}")
 
 
@@ -190,6 +210,8 @@ def check_hashcat_version(hashcat_path: str = "hashcat"):
             bt.logging.info(f"Version of hashcat found: {process.stdout.decode()}".strip("\n"))
         return True
     except subprocess.CalledProcessError:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(
             f"Hashcat is not available nor installed on the machine. Please make sure hashcat is available in your PATH or give the explicit location using the following argument: --miner.hashcat.path"
         )

--- a/neurons/Miner/allocate.py
+++ b/neurons/Miner/allocate.py
@@ -16,6 +16,8 @@
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
 
+import sentry_sdk
+import sentry_sdk
 import bittensor as bt
 import base64
 import docker
@@ -57,6 +59,8 @@ def register_allocation(timeline, device_requirement, public_key):
         return run_status
     
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Error allocating container {e}")
     return {"status": False}
 
@@ -89,6 +93,8 @@ def deregister_allocation(public_key):
             return {"status": False}
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Error de-allocating container {e}")
         return {"status": False}
 
@@ -131,6 +137,8 @@ def check_if_allocated(public_key):
         # All checks passed, return True
         return {"status": True}
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # Handle any exceptions that occur
         # Log the exception or handle it as needed
         return {"status": False}

--- a/neurons/Miner/allocate.py
+++ b/neurons/Miner/allocate.py
@@ -16,8 +16,8 @@
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
 
-import sentry_sdk
-import sentry_sdk
+
+
 import bittensor as bt
 import base64
 import docker
@@ -59,8 +59,8 @@ def register_allocation(timeline, device_requirement, public_key):
         return run_status
     
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.info(f"Error allocating container {e}")
     return {"status": False}
 
@@ -93,8 +93,8 @@ def deregister_allocation(public_key):
             return {"status": False}
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.info(f"Error de-allocating container {e}")
         return {"status": False}
 
@@ -137,8 +137,8 @@ def check_if_allocated(public_key):
         # All checks passed, return True
         return {"status": True}
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # Handle any exceptions that occur
         # Log the exception or handle it as needed
         return {"status": False}

--- a/neurons/Miner/allocate.py
+++ b/neurons/Miner/allocate.py
@@ -18,6 +18,7 @@
 
 
 
+import sentry_sdk
 import bittensor as bt
 import base64
 import docker
@@ -59,6 +60,7 @@ def register_allocation(timeline, device_requirement, public_key):
         return run_status
     
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.info(f"Error allocating container {e}")
@@ -93,6 +95,7 @@ def deregister_allocation(public_key):
             return {"status": False}
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.info(f"Error de-allocating container {e}")
@@ -137,6 +140,7 @@ def check_if_allocated(public_key):
         # All checks passed, return True
         return {"status": True}
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         # Handle any exceptions that occur

--- a/neurons/Miner/container.py
+++ b/neurons/Miner/container.py
@@ -16,8 +16,8 @@
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
 
-import sentry_sdk
-import sentry_sdk
+
+
 import base64
 import json
 import os
@@ -69,8 +69,8 @@ def kill_container():
             # bt.logging.info("Unable to find container")
             return False
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # bt.logging.info(f"Error killing container {e}")
         return False
 
@@ -150,8 +150,8 @@ def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key):
             # bt.logging.info(f"Container falied with status : {container.status}")
             return {"status": False}
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # bt.logging.info(f"Error running container {e}")
         return {"status": False}
 
@@ -165,8 +165,8 @@ def check_container():
                 return True
         return False
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # bt.logging.info(f"Error checking container {e}")
         return False
 
@@ -209,11 +209,11 @@ def build_check_container(image_name: str, container_name: str):
         container = client.containers.create(image_name, name=container_name)
         return container
     except docker.errors.BuildError:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         pass
     except docker.errors.APIError:
-        sentry_sdk.capture_exception()
+        
         pass
     finally:
         client.close()

--- a/neurons/Miner/container.py
+++ b/neurons/Miner/container.py
@@ -16,6 +16,8 @@
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
 
+import sentry_sdk
+import sentry_sdk
 import base64
 import json
 import os
@@ -67,6 +69,8 @@ def kill_container():
             # bt.logging.info("Unable to find container")
             return False
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # bt.logging.info(f"Error killing container {e}")
         return False
 
@@ -146,6 +150,8 @@ def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key):
             # bt.logging.info(f"Container falied with status : {container.status}")
             return {"status": False}
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # bt.logging.info(f"Error running container {e}")
         return {"status": False}
 
@@ -159,6 +165,8 @@ def check_container():
                 return True
         return False
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # bt.logging.info(f"Error checking container {e}")
         return False
 
@@ -201,8 +209,11 @@ def build_check_container(image_name: str, container_name: str):
         container = client.containers.create(image_name, name=container_name)
         return container
     except docker.errors.BuildError:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         pass
     except docker.errors.APIError:
+        sentry_sdk.capture_exception()
         pass
     finally:
         client.close()

--- a/neurons/Miner/container.py
+++ b/neurons/Miner/container.py
@@ -18,6 +18,7 @@
 
 
 
+import sentry_sdk
 import base64
 import json
 import os
@@ -69,6 +70,7 @@ def kill_container():
             # bt.logging.info("Unable to find container")
             return False
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         # bt.logging.info(f"Error killing container {e}")
@@ -150,6 +152,7 @@ def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key):
             # bt.logging.info(f"Container falied with status : {container.status}")
             return {"status": False}
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         # bt.logging.info(f"Error running container {e}")
@@ -165,6 +168,7 @@ def check_container():
                 return True
         return False
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         # bt.logging.info(f"Error checking container {e}")
@@ -209,10 +213,12 @@ def build_check_container(image_name: str, container_name: str):
         container = client.containers.create(image_name, name=container_name)
         return container
     except docker.errors.BuildError:
+        sentry_sdk.capture_exception()
         
         
         pass
     except docker.errors.APIError:
+        sentry_sdk.capture_exception()
         
         pass
     finally:

--- a/neurons/Miner/kill_container.py
+++ b/neurons/Miner/kill_container.py
@@ -19,6 +19,7 @@
 
 
 
+import sentry_sdk
 import docker
 
 container_name = "ssh-container"  # Docker container name
@@ -41,6 +42,7 @@ def kill_container():
             running_container.remove()
             return True
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         # bt.logging.info(f"Error killing container {e}")

--- a/neurons/Miner/kill_container.py
+++ b/neurons/Miner/kill_container.py
@@ -17,6 +17,8 @@
 # Step 1: Import necessary libraries and modules
 
 
+import sentry_sdk
+import sentry_sdk
 import docker
 
 container_name = "ssh-container"  # Docker container name
@@ -39,6 +41,8 @@ def kill_container():
             running_container.remove()
             return True
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # bt.logging.info(f"Error killing container {e}")
         return False
 

--- a/neurons/Miner/kill_container.py
+++ b/neurons/Miner/kill_container.py
@@ -17,8 +17,8 @@
 # Step 1: Import necessary libraries and modules
 
 
-import sentry_sdk
-import sentry_sdk
+
+
 import docker
 
 container_name = "ssh-container"  # Docker container name
@@ -41,8 +41,8 @@ def kill_container():
             running_container.remove()
             return True
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # bt.logging.info(f"Error killing container {e}")
         return False
 

--- a/neurons/Miner/pow.py
+++ b/neurons/Miner/pow.py
@@ -13,8 +13,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-import sentry_sdk
-import sentry_sdk
+
+
 import shlex
 import subprocess
 from typing import Union
@@ -147,8 +147,8 @@ def run_hashcat(
             }
 
     except subprocess.TimeoutExpired:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         execution_time = time.time() - start_time
         error_message = f"{run_id}: ❌ Hashcat execution timed out"
         bt.logging.warning(error_message)
@@ -159,8 +159,8 @@ def run_hashcat(
             "error": error_message,
         }
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         execution_time = time.time() - start_time
         bt.logging.warning(f"{unknown_error_message}: {e}")
         queue.popleft()

--- a/neurons/Miner/pow.py
+++ b/neurons/Miner/pow.py
@@ -13,6 +13,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+import sentry_sdk
+import sentry_sdk
 import shlex
 import subprocess
 from typing import Union
@@ -145,6 +147,8 @@ def run_hashcat(
             }
 
     except subprocess.TimeoutExpired:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         execution_time = time.time() - start_time
         error_message = f"{run_id}: ❌ Hashcat execution timed out"
         bt.logging.warning(error_message)
@@ -155,6 +159,8 @@ def run_hashcat(
             "error": error_message,
         }
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         execution_time = time.time() - start_time
         bt.logging.warning(f"{unknown_error_message}: {e}")
         queue.popleft()

--- a/neurons/Miner/pow.py
+++ b/neurons/Miner/pow.py
@@ -15,6 +15,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import sentry_sdk
 import shlex
 import subprocess
 from typing import Union
@@ -147,6 +148,7 @@ def run_hashcat(
             }
 
     except subprocess.TimeoutExpired:
+        sentry_sdk.capture_exception()
         
         
         execution_time = time.time() - start_time
@@ -159,6 +161,7 @@ def run_hashcat(
             "error": error_message,
         }
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         execution_time = time.time() - start_time

--- a/neurons/Miner/specs.py
+++ b/neurons/Miner/specs.py
@@ -15,8 +15,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-import sentry_sdk
-import sentry_sdk
+
+
 import ast
 import os
 import subprocess
@@ -63,8 +63,8 @@ class RequestSpecsProcessor:
             subprocess.run(f"chmod +x {file_path}", shell=True, check=True)
             result = subprocess.check_output([file_path], shell=True, text=True)
         except Exception as e:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             traceback.print_exc()
             result = {"process_request error": str(e)}
         finally:
@@ -91,7 +91,7 @@ class RequestSpecsProcessor:
             bt.logging.info(f"💻 Specs query finalized {request_id} ...")
             return result
         except Exception as e:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             traceback.print_exc()
             return {"get_respond error": str(e)}

--- a/neurons/Miner/specs.py
+++ b/neurons/Miner/specs.py
@@ -15,6 +15,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+import sentry_sdk
+import sentry_sdk
 import ast
 import os
 import subprocess
@@ -61,6 +63,8 @@ class RequestSpecsProcessor:
             subprocess.run(f"chmod +x {file_path}", shell=True, check=True)
             result = subprocess.check_output([file_path], shell=True, text=True)
         except Exception as e:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             traceback.print_exc()
             result = {"process_request error": str(e)}
         finally:
@@ -87,5 +91,7 @@ class RequestSpecsProcessor:
             bt.logging.info(f"💻 Specs query finalized {request_id} ...")
             return result
         except Exception as e:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             traceback.print_exc()
             return {"get_respond error": str(e)}

--- a/neurons/Miner/specs.py
+++ b/neurons/Miner/specs.py
@@ -17,6 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import sentry_sdk
 import ast
 import os
 import subprocess
@@ -63,6 +64,7 @@ class RequestSpecsProcessor:
             subprocess.run(f"chmod +x {file_path}", shell=True, check=True)
             result = subprocess.check_output([file_path], shell=True, text=True)
         except Exception as e:
+            sentry_sdk.capture_exception()
             
             
             traceback.print_exc()
@@ -91,6 +93,7 @@ class RequestSpecsProcessor:
             bt.logging.info(f"💻 Specs query finalized {request_id} ...")
             return result
         except Exception as e:
+            sentry_sdk.capture_exception()
             
             
             traceback.print_exc()

--- a/neurons/Validator/app_generator.py
+++ b/neurons/Validator/app_generator.py
@@ -16,6 +16,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import sentry_sdk
+import sentry_sdk
 import os
 import re
 import subprocess
@@ -67,7 +69,11 @@ def run(secret_key):
             stdout_thread.join()
             stderr_thread.join()
         except subprocess.CalledProcessError as e:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             bt.logging.error("An error occurred while generating the app.")
             bt.logging.error(f"Error output:{e.stderr.decode()}")
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"{e}")

--- a/neurons/Validator/app_generator.py
+++ b/neurons/Validator/app_generator.py
@@ -18,6 +18,7 @@
 
 
 
+import sentry_sdk
 import os
 import re
 import subprocess
@@ -69,11 +70,13 @@ def run(secret_key):
             stdout_thread.join()
             stderr_thread.join()
         except subprocess.CalledProcessError as e:
+            sentry_sdk.capture_exception()
             
             
             bt.logging.error("An error occurred while generating the app.")
             bt.logging.error(f"Error output:{e.stderr.decode()}")
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"{e}")

--- a/neurons/Validator/app_generator.py
+++ b/neurons/Validator/app_generator.py
@@ -16,8 +16,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import sentry_sdk
-import sentry_sdk
+
+
 import os
 import re
 import subprocess
@@ -69,11 +69,11 @@ def run(secret_key):
             stdout_thread.join()
             stderr_thread.join()
         except subprocess.CalledProcessError as e:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             bt.logging.error("An error occurred while generating the app.")
             bt.logging.error(f"Error output:{e.stderr.decode()}")
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"{e}")

--- a/neurons/Validator/calculate_pow_score.py
+++ b/neurons/Validator/calculate_pow_score.py
@@ -16,8 +16,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
-import sentry_sdk
-import sentry_sdk
+
+
 import bittensor as bt
 import wandb
 
@@ -132,8 +132,8 @@ def calc_score(response, hotkey, mock=False):
         normalized_score = normalize(final_score, 0, max_score)
         return normalized_score
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"An error occurred while calculating score for the following hotkey - {hotkey}: {e}")
         return 0
     
@@ -172,15 +172,15 @@ def check_latest_allocation_status(hotkey, mock=False):
                             return latest_status
                     
             except Exception as e:
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
+                
                 print(f"Error fetching data from run '{run.id}': {e}")
 
         # Return False if the hotkey was not found 
         return False
           
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error("Error checking latest allocation status:", e)
         return None

--- a/neurons/Validator/calculate_pow_score.py
+++ b/neurons/Validator/calculate_pow_score.py
@@ -16,6 +16,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
+import sentry_sdk
+import sentry_sdk
 import bittensor as bt
 import wandb
 
@@ -130,6 +132,8 @@ def calc_score(response, hotkey, mock=False):
         normalized_score = normalize(final_score, 0, max_score)
         return normalized_score
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"An error occurred while calculating score for the following hotkey - {hotkey}: {e}")
         return 0
     
@@ -168,11 +172,15 @@ def check_latest_allocation_status(hotkey, mock=False):
                             return latest_status
                     
             except Exception as e:
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 print(f"Error fetching data from run '{run.id}': {e}")
 
         # Return False if the hotkey was not found 
         return False
           
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error("Error checking latest allocation status:", e)
         return None

--- a/neurons/Validator/calculate_pow_score.py
+++ b/neurons/Validator/calculate_pow_score.py
@@ -18,6 +18,7 @@
 # Step 1: Import necessary libraries and modules
 
 
+import sentry_sdk
 import bittensor as bt
 import wandb
 
@@ -132,6 +133,7 @@ def calc_score(response, hotkey, mock=False):
         normalized_score = normalize(final_score, 0, max_score)
         return normalized_score
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"An error occurred while calculating score for the following hotkey - {hotkey}: {e}")
@@ -172,6 +174,7 @@ def check_latest_allocation_status(hotkey, mock=False):
                             return latest_status
                     
             except Exception as e:
+                sentry_sdk.capture_exception()
                 
                 
                 print(f"Error fetching data from run '{run.id}': {e}")
@@ -180,6 +183,7 @@ def check_latest_allocation_status(hotkey, mock=False):
         return False
           
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error("Error checking latest allocation status:", e)

--- a/neurons/Validator/calculate_score.py
+++ b/neurons/Validator/calculate_score.py
@@ -17,6 +17,8 @@
 # Step 1: Import necessary libraries and modules
 
 
+import sentry_sdk
+import sentry_sdk
 import numpy as np
 import wandb
 
@@ -60,6 +62,8 @@ def score(data, hotkey):
 
         return 10 + np.dot(score_list, weight_list).item() * 100 + registration_bonus
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return 0
 
 
@@ -71,6 +75,8 @@ def get_cpu_score(cpu_info):
         level = 75  # 30, 2.5
         return count * frequency / 1024 / level
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return 0
 
 
@@ -82,6 +88,8 @@ def get_gpu_score(gpu_info):
         speed = (gpu_info["graphics_speed"] + gpu_info["memory_speed"]) / 2
         return capacity * speed / level
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return 0
 
 
@@ -94,6 +102,8 @@ def get_hard_disk_score(hard_disk_info):
 
         return capacity * speed / level
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return 0
 
 
@@ -105,6 +115,8 @@ def get_ram_score(ram_info):
         speed = ram_info["read_speed"]
         return capacity * speed / level
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return 0
 
 
@@ -121,4 +133,6 @@ def check_if_registered(hotkey):
         else:
             return False
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return False

--- a/neurons/Validator/calculate_score.py
+++ b/neurons/Validator/calculate_score.py
@@ -17,8 +17,8 @@
 # Step 1: Import necessary libraries and modules
 
 
-import sentry_sdk
-import sentry_sdk
+
+
 import numpy as np
 import wandb
 
@@ -62,8 +62,8 @@ def score(data, hotkey):
 
         return 10 + np.dot(score_list, weight_list).item() * 100 + registration_bonus
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return 0
 
 
@@ -75,8 +75,8 @@ def get_cpu_score(cpu_info):
         level = 75  # 30, 2.5
         return count * frequency / 1024 / level
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return 0
 
 
@@ -88,8 +88,8 @@ def get_gpu_score(gpu_info):
         speed = (gpu_info["graphics_speed"] + gpu_info["memory_speed"]) / 2
         return capacity * speed / level
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return 0
 
 
@@ -102,8 +102,8 @@ def get_hard_disk_score(hard_disk_info):
 
         return capacity * speed / level
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return 0
 
 
@@ -115,8 +115,8 @@ def get_ram_score(ram_info):
         speed = ram_info["read_speed"]
         return capacity * speed / level
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return 0
 
 
@@ -133,6 +133,6 @@ def check_if_registered(hotkey):
         else:
             return False
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return False

--- a/neurons/Validator/calculate_score.py
+++ b/neurons/Validator/calculate_score.py
@@ -19,6 +19,7 @@
 
 
 
+import sentry_sdk
 import numpy as np
 import wandb
 
@@ -62,6 +63,7 @@ def score(data, hotkey):
 
         return 10 + np.dot(score_list, weight_list).item() * 100 + registration_bonus
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return 0
@@ -75,6 +77,7 @@ def get_cpu_score(cpu_info):
         level = 75  # 30, 2.5
         return count * frequency / 1024 / level
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return 0
@@ -88,6 +91,7 @@ def get_gpu_score(gpu_info):
         speed = (gpu_info["graphics_speed"] + gpu_info["memory_speed"]) / 2
         return capacity * speed / level
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return 0
@@ -102,6 +106,7 @@ def get_hard_disk_score(hard_disk_info):
 
         return capacity * speed / level
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return 0
@@ -115,6 +120,7 @@ def get_ram_score(ram_info):
         speed = ram_info["read_speed"]
         return capacity * speed / level
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return 0
@@ -133,6 +139,7 @@ def check_if_registered(hotkey):
         else:
             return False
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return False

--- a/neurons/Validator/database/allocate.py
+++ b/neurons/Validator/database/allocate.py
@@ -17,6 +17,7 @@
 
 
 
+import sentry_sdk
 import json
 from typing import Tuple, Any
 
@@ -40,6 +41,7 @@ def select_has_docker_miners_hotkey(db: ComputeDb):
                     uid_hotkey_dict[row[0]] = row[1]
         return uid_hotkey_dict
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"Error while getting hotkeys from miner_details : {e}")
@@ -64,6 +66,7 @@ def select_allocate_miners_hotkey(db: ComputeDb, device_requirement):
                 hotkey_list.append(row[1])
         return hotkey_list
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"Error while getting hotkeys from miner_details : {e}")
@@ -88,6 +91,7 @@ def update_miner_details(db: ComputeDb, hotkey_list, benchmark_responses: Tuple[
                 cursor.execute("DELETE FROM challenge_details WHERE uid IN (SELECT uid FROM miner WHERE unresponsive_count >= 10);")
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         db.conn.rollback()
@@ -176,6 +180,7 @@ def update_miner_details(db: ComputeDb, hotkey_list, benchmark_responses: Tuple[
                 """, (hotkey_list[index], hotkey, '{}'))
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         db.conn.rollback()
@@ -207,6 +212,7 @@ def get_miner_details(db):
             else:  # If details are empty, set the value to an empty dictionary
                 miner_specs_details[hotkey] = {}
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"Error while retrieving miner details: {e}")
@@ -233,6 +239,7 @@ def update_allocation_db(hotkey: str, info: str, flag: bool):
             cursor.execute("DELETE FROM allocation WHERE hotkey = ?", (hotkey,))
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         db.conn.rollback()
@@ -277,6 +284,7 @@ def allocate_check_if_miner_meet(details, required_details):
         if required_ram and (not ram_miner or ram_miner["available"] < required_ram["capacity"]):
             return False
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error("The format is wrong, please check it again.")

--- a/neurons/Validator/database/allocate.py
+++ b/neurons/Validator/database/allocate.py
@@ -15,6 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import sentry_sdk
+import sentry_sdk
 import json
 from typing import Tuple, Any
 
@@ -38,6 +40,8 @@ def select_has_docker_miners_hotkey(db: ComputeDb):
                     uid_hotkey_dict[row[0]] = row[1]
         return uid_hotkey_dict
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error while getting hotkeys from miner_details : {e}")
         return []
     finally:
@@ -60,6 +64,8 @@ def select_allocate_miners_hotkey(db: ComputeDb, device_requirement):
                 hotkey_list.append(row[1])
         return hotkey_list
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error while getting hotkeys from miner_details : {e}")
         return []
     finally:
@@ -82,6 +88,8 @@ def update_miner_details(db: ComputeDb, hotkey_list, benchmark_responses: Tuple[
                 cursor.execute("DELETE FROM challenge_details WHERE uid IN (SELECT uid FROM miner WHERE unresponsive_count >= 10);")
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         db.conn.rollback()
         bt.logging.error(f"Error while updating miner_details : {e}")
     finally:
@@ -168,6 +176,8 @@ def update_miner_details(db: ComputeDb, hotkey_list, benchmark_responses: Tuple[
                 """, (hotkey_list[index], hotkey, '{}'))
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         db.conn.rollback()
         bt.logging.error(f"Error while updating miner_details: {e}")
     finally:
@@ -197,6 +207,8 @@ def get_miner_details(db):
             else:  # If details are empty, set the value to an empty dictionary
                 miner_specs_details[hotkey] = {}
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error while retrieving miner details: {e}")
     finally:
         cursor.close()
@@ -221,6 +233,8 @@ def update_allocation_db(hotkey: str, info: str, flag: bool):
             cursor.execute("DELETE FROM allocation WHERE hotkey = ?", (hotkey,))
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         db.conn.rollback()
         bt.logging.error(f"Error while updating allocation details: {e}")
     finally:
@@ -263,6 +277,8 @@ def allocate_check_if_miner_meet(details, required_details):
         if required_ram and (not ram_miner or ram_miner["available"] < required_ram["capacity"]):
             return False
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error("The format is wrong, please check it again.")
         return False
     return True

--- a/neurons/Validator/database/allocate.py
+++ b/neurons/Validator/database/allocate.py
@@ -15,8 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import sentry_sdk
-import sentry_sdk
+
+
 import json
 from typing import Tuple, Any
 
@@ -40,8 +40,8 @@ def select_has_docker_miners_hotkey(db: ComputeDb):
                     uid_hotkey_dict[row[0]] = row[1]
         return uid_hotkey_dict
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"Error while getting hotkeys from miner_details : {e}")
         return []
     finally:
@@ -64,8 +64,8 @@ def select_allocate_miners_hotkey(db: ComputeDb, device_requirement):
                 hotkey_list.append(row[1])
         return hotkey_list
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"Error while getting hotkeys from miner_details : {e}")
         return []
     finally:
@@ -88,8 +88,8 @@ def update_miner_details(db: ComputeDb, hotkey_list, benchmark_responses: Tuple[
                 cursor.execute("DELETE FROM challenge_details WHERE uid IN (SELECT uid FROM miner WHERE unresponsive_count >= 10);")
         db.conn.commit()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         db.conn.rollback()
         bt.logging.error(f"Error while updating miner_details : {e}")
     finally:
@@ -176,8 +176,8 @@ def update_miner_details(db: ComputeDb, hotkey_list, benchmark_responses: Tuple[
                 """, (hotkey_list[index], hotkey, '{}'))
         db.conn.commit()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         db.conn.rollback()
         bt.logging.error(f"Error while updating miner_details: {e}")
     finally:
@@ -207,8 +207,8 @@ def get_miner_details(db):
             else:  # If details are empty, set the value to an empty dictionary
                 miner_specs_details[hotkey] = {}
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"Error while retrieving miner details: {e}")
     finally:
         cursor.close()
@@ -233,8 +233,8 @@ def update_allocation_db(hotkey: str, info: str, flag: bool):
             cursor.execute("DELETE FROM allocation WHERE hotkey = ?", (hotkey,))
         db.conn.commit()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         db.conn.rollback()
         bt.logging.error(f"Error while updating allocation details: {e}")
     finally:
@@ -277,8 +277,8 @@ def allocate_check_if_miner_meet(details, required_details):
         if required_ram and (not ram_miner or ram_miner["available"] < required_ram["capacity"]):
             return False
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error("The format is wrong, please check it again.")
         return False
     return True

--- a/neurons/Validator/database/challenge.py
+++ b/neurons/Validator/database/challenge.py
@@ -16,6 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import sentry_sdk
 import datetime
 
 import bittensor as bt
@@ -166,6 +167,7 @@ def update_challenge_details(db: ComputeDb, pow_benchmarks: list):
         )
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         db.conn.rollback()

--- a/neurons/Validator/database/challenge.py
+++ b/neurons/Validator/database/challenge.py
@@ -14,6 +14,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+import sentry_sdk
+import sentry_sdk
 import datetime
 
 import bittensor as bt
@@ -164,6 +166,8 @@ def update_challenge_details(db: ComputeDb, pow_benchmarks: list):
         )
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         db.conn.rollback()
         bt.logging.error(f"Error while updating challenge_details: {e}")
     finally:

--- a/neurons/Validator/database/challenge.py
+++ b/neurons/Validator/database/challenge.py
@@ -14,8 +14,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-import sentry_sdk
-import sentry_sdk
+
+
 import datetime
 
 import bittensor as bt
@@ -166,8 +166,8 @@ def update_challenge_details(db: ComputeDb, pow_benchmarks: list):
         )
         db.conn.commit()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         db.conn.rollback()
         bt.logging.error(f"Error while updating challenge_details: {e}")
     finally:

--- a/neurons/Validator/database/miner.py
+++ b/neurons/Validator/database/miner.py
@@ -17,6 +17,7 @@
 
 
 
+import sentry_sdk
 import bittensor as bt
 
 from compute.utils.db import ComputeDb
@@ -56,6 +57,7 @@ def update_miners(db: ComputeDb, miners: list):
         # Commit changes
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         db.conn.rollback()
@@ -90,6 +92,7 @@ def purge_miner_entries(db: ComputeDb, uid: int, hotkey: str):
         else:
             bt.logging.info(f"No matching entries found for UID '{uid}' and Hotkey '{hotkey}'. No deletion performed.")
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"Error while purging entries: {e}")

--- a/neurons/Validator/database/miner.py
+++ b/neurons/Validator/database/miner.py
@@ -15,8 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import sentry_sdk
-import sentry_sdk
+
+
 import bittensor as bt
 
 from compute.utils.db import ComputeDb
@@ -56,8 +56,8 @@ def update_miners(db: ComputeDb, miners: list):
         # Commit changes
         db.conn.commit()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         db.conn.rollback()
         bt.logging.error(f"Error while updating update_miners: {e}")
     finally:
@@ -90,8 +90,8 @@ def purge_miner_entries(db: ComputeDb, uid: int, hotkey: str):
         else:
             bt.logging.info(f"No matching entries found for UID '{uid}' and Hotkey '{hotkey}'. No deletion performed.")
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"Error while purging entries: {e}")
     finally:
         cursor.close()

--- a/neurons/Validator/database/miner.py
+++ b/neurons/Validator/database/miner.py
@@ -15,6 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import sentry_sdk
+import sentry_sdk
 import bittensor as bt
 
 from compute.utils.db import ComputeDb
@@ -54,6 +56,8 @@ def update_miners(db: ComputeDb, miners: list):
         # Commit changes
         db.conn.commit()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         db.conn.rollback()
         bt.logging.error(f"Error while updating update_miners: {e}")
     finally:
@@ -86,6 +90,8 @@ def purge_miner_entries(db: ComputeDb, uid: int, hotkey: str):
         else:
             bt.logging.info(f"No matching entries found for UID '{uid}' and Hotkey '{hotkey}'. No deletion performed.")
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error while purging entries: {e}")
     finally:
         cursor.close()

--- a/neurons/Validator/pow.py
+++ b/neurons/Validator/pow.py
@@ -16,6 +16,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import sentry_sdk
 import hashlib
 import random
 import secrets
@@ -58,6 +59,7 @@ def gen_password(available_chars=compute.pow_default_chars, length=compute.pow_m
         _hash, _salt = gen_hash(password)
         return password, _hash, _salt, _mask
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.error(f"Error during PoW generation (gen_password): {e}")

--- a/neurons/Validator/pow.py
+++ b/neurons/Validator/pow.py
@@ -14,8 +14,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-import sentry_sdk
-import sentry_sdk
+
+
 import hashlib
 import random
 import secrets
@@ -58,8 +58,8 @@ def gen_password(available_chars=compute.pow_default_chars, length=compute.pow_m
         _hash, _salt = gen_hash(password)
         return password, _hash, _salt, _mask
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.error(f"Error during PoW generation (gen_password): {e}")
         return None
 

--- a/neurons/Validator/pow.py
+++ b/neurons/Validator/pow.py
@@ -14,6 +14,8 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+import sentry_sdk
+import sentry_sdk
 import hashlib
 import random
 import secrets
@@ -56,6 +58,8 @@ def gen_password(available_chars=compute.pow_default_chars, length=compute.pow_m
         _hash, _salt = gen_hash(password)
         return password, _hash, _salt, _mask
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.error(f"Error during PoW generation (gen_password): {e}")
         return None
 

--- a/neurons/Validator/script.py
+++ b/neurons/Validator/script.py
@@ -17,6 +17,7 @@
 # Step 1: Import necessary libraries and modules
 
 
+import sentry_sdk
 import psutil
 import GPUtil
 import json
@@ -43,6 +44,7 @@ def get_cpu_info():
 
         return info
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return {}
@@ -77,6 +79,7 @@ def get_gpu_info():
         return info
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return {}
@@ -98,6 +101,7 @@ def get_hard_disk_info():
                     {"device": partition.device, "mountpoint": partition.mountpoint, "total": usage.total, "used": usage.used, "free": usage.free}
                 )
             except Exception as e:
+                sentry_sdk.capture_exception()
                 
                 
                 continue
@@ -130,6 +134,7 @@ def get_hard_disk_info():
 
         return info
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return {}
@@ -173,6 +178,7 @@ def get_ram_info():
 
         return info
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         return {}
@@ -193,6 +199,7 @@ def check_docker_availability() -> Tuple[bool, str]:
             return False, error_message
 
     except Exception as e:  # Catch all exceptions
+        sentry_sdk.capture_exception()
         
         
         # If the command failed, Docker is not installed
@@ -234,6 +241,7 @@ def check_docker_container(container_id_or_name: str):
             return False
 
     except subprocess.CalledProcessError as e:
+        sentry_sdk.capture_exception()
         
         
         # Handle errors from the Docker CLI

--- a/neurons/Validator/script.py
+++ b/neurons/Validator/script.py
@@ -15,8 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
-import sentry_sdk
-import sentry_sdk
+
+
 import psutil
 import GPUtil
 import json
@@ -43,8 +43,8 @@ def get_cpu_info():
 
         return info
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return {}
 
 
@@ -77,8 +77,8 @@ def get_gpu_info():
         return info
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return {}
 
 
@@ -98,8 +98,8 @@ def get_hard_disk_info():
                     {"device": partition.device, "mountpoint": partition.mountpoint, "total": usage.total, "used": usage.used, "free": usage.free}
                 )
             except Exception as e:
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
+                
                 continue
 
         # Measure write speed
@@ -130,8 +130,8 @@ def get_hard_disk_info():
 
         return info
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return {}
 
 
@@ -173,8 +173,8 @@ def get_ram_info():
 
         return info
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         return {}
 
 
@@ -193,8 +193,8 @@ def check_docker_availability() -> Tuple[bool, str]:
             return False, error_message
 
     except Exception as e:  # Catch all exceptions
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # If the command failed, Docker is not installed
         error_message = (
             "Docker is not installed or not found in the system PATH. "
@@ -234,8 +234,8 @@ def check_docker_container(container_id_or_name: str):
             return False
 
     except subprocess.CalledProcessError as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         # Handle errors from the Docker CLI
         return False
 

--- a/neurons/Validator/script.py
+++ b/neurons/Validator/script.py
@@ -15,6 +15,8 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 # Step 1: Import necessary libraries and modules
+import sentry_sdk
+import sentry_sdk
 import psutil
 import GPUtil
 import json
@@ -41,6 +43,8 @@ def get_cpu_info():
 
         return info
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return {}
 
 
@@ -73,6 +77,8 @@ def get_gpu_info():
         return info
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return {}
 
 
@@ -92,6 +98,8 @@ def get_hard_disk_info():
                     {"device": partition.device, "mountpoint": partition.mountpoint, "total": usage.total, "used": usage.used, "free": usage.free}
                 )
             except Exception as e:
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 continue
 
         # Measure write speed
@@ -122,6 +130,8 @@ def get_hard_disk_info():
 
         return info
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return {}
 
 
@@ -163,6 +173,8 @@ def get_ram_info():
 
         return info
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         return {}
 
 
@@ -181,6 +193,8 @@ def check_docker_availability() -> Tuple[bool, str]:
             return False, error_message
 
     except Exception as e:  # Catch all exceptions
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # If the command failed, Docker is not installed
         error_message = (
             "Docker is not installed or not found in the system PATH. "
@@ -220,6 +234,8 @@ def check_docker_container(container_id_or_name: str):
             return False
 
     except subprocess.CalledProcessError as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         # Handle errors from the Docker CLI
         return False
 

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -15,7 +15,7 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
-import sentry_sdk
+
 import asyncio
 import json
 import os
@@ -397,17 +397,15 @@ class Miner:
 
                             bt.logging.debug(f"Version signature mismatch for hotkey : {hotkey}")
                         except Exception:
-                            sentry_sdk.capture_exception()
-                            sentry_sdk.capture_exception()
+                            
                             bt.logging.error(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
 
                     bt.logging.info(f"Total valid validator hotkeys = {self.whitelist_hotkeys_version}")
             except json.JSONDecodeError:
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
                 bt.logging.error(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
         except Exception as _:
-            sentry_sdk.capture_exception()
+            
             bt.logging.error(traceback.format_exc())
 
     def get_valid_validator_uids(self):
@@ -483,15 +481,13 @@ class Miner:
                 time.sleep(5)
 
             except (RuntimeError, Exception) as e:
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
                 bt.logging.error(e)
                 traceback.print_exc()
 
             # If the user interrupts the program, gracefully exit.
             except KeyboardInterrupt:
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
                 self.axon.stop()
                 bt.logging.success("Keyboard interrupt detected. Exiting miner.")
                 exit()

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -16,6 +16,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import sentry_sdk
 import asyncio
 import json
 import os
@@ -397,11 +398,13 @@ class Miner:
 
                             bt.logging.debug(f"Version signature mismatch for hotkey : {hotkey}")
                         except Exception:
+                            sentry_sdk.capture_exception()
                             
                             bt.logging.error(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
 
                     bt.logging.info(f"Total valid validator hotkeys = {self.whitelist_hotkeys_version}")
             except json.JSONDecodeError:
+                sentry_sdk.capture_exception()
                 
                 bt.logging.error(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
         except Exception as _:
@@ -481,12 +484,14 @@ class Miner:
                 time.sleep(5)
 
             except (RuntimeError, Exception) as e:
+                sentry_sdk.capture_exception()
                 
                 bt.logging.error(e)
                 traceback.print_exc()
 
             # If the user interrupts the program, gracefully exit.
             except KeyboardInterrupt:
+                sentry_sdk.capture_exception()
                 
                 self.axon.stop()
                 bt.logging.success("Keyboard interrupt detected. Exiting miner.")

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -15,6 +15,7 @@
 # THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
+import sentry_sdk
 import asyncio
 import json
 import os
@@ -22,7 +23,6 @@ import traceback
 import typing
 
 import bittensor as bt
-import sentry_sdk
 import time
 
 from compute import (
@@ -397,12 +397,17 @@ class Miner:
 
                             bt.logging.debug(f"Version signature mismatch for hotkey : {hotkey}")
                         except Exception:
+                            sentry_sdk.capture_exception()
+                            sentry_sdk.capture_exception()
                             bt.logging.error(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
 
                     bt.logging.info(f"Total valid validator hotkeys = {self.whitelist_hotkeys_version}")
             except json.JSONDecodeError:
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 bt.logging.error(f"exception in get_valid_hotkeys: {traceback.format_exc()}")
         except Exception as _:
+            sentry_sdk.capture_exception()
             bt.logging.error(traceback.format_exc())
 
     def get_valid_validator_uids(self):
@@ -478,11 +483,15 @@ class Miner:
                 time.sleep(5)
 
             except (RuntimeError, Exception) as e:
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 bt.logging.error(e)
                 traceback.print_exc()
 
             # If the user interrupts the program, gracefully exit.
             except KeyboardInterrupt:
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 self.axon.stop()
                 bt.logging.success("Keyboard interrupt detected. Exiting miner.")
                 exit()

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -22,6 +22,7 @@ import traceback
 import typing
 
 import bittensor as bt
+import sentry_sdk
 import time
 
 from compute import (
@@ -36,6 +37,7 @@ from compute.axon import ComputeSubnetAxon, ComputeSubnetSubtensor
 from compute.protocol import Specs, Allocate, Challenge
 from compute.utils.math import percent
 from compute.utils.parser import ComputeArgPaser
+from compute.utils.sentry import init_sentry
 from compute.utils.subtensor import (
     is_registered,
     get_current_block,
@@ -93,6 +95,7 @@ class Miner:
     def __init__(self):
         # Step 1: Parse the bittensor and compute subnet config
         self.config = self.init_config()
+        init_sentry(self.config, {"node-type": "miner"})
 
         # Setup extra args
         self.miner_whitelist_updated_threshold = self.config.miner_whitelist_updated_threshold

--- a/neurons/register.py
+++ b/neurons/register.py
@@ -18,8 +18,8 @@
 # Step 1: Import necessary libraries and modules
 
 
-import sentry_sdk
-import sentry_sdk
+
+
 import argparse
 import base64
 import os
@@ -255,8 +255,8 @@ def allocate():
                     gpu_name = str(gpu_miner['details'][0]['name']).lower()
                     break
                 except (KeyError, IndexError, TypeError):
-                    sentry_sdk.capture_exception()
-                    sentry_sdk.capture_exception()
+                    
+                    
                     gpu_name = "Invalid details"
             else:
                 gpu_name = "No details available"
@@ -316,8 +316,8 @@ def allocate_hotkey():
                 gpu_name = str(gpu_miner['details'][0]['name']).lower()
                 break
             except (KeyError, IndexError, TypeError):
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
+                
                 gpu_name = "Invalid details"
         else:
             gpu_name = "No details available"
@@ -431,8 +431,8 @@ def deallocate():
             print("No allocation details found for the provided hotkey.")
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         print(f"An error occurred during de-allocation: {e}")
     finally:
         cursor.close()
@@ -474,8 +474,8 @@ def check_and_update_existing_allocations():
             public_key_list.append(info['regkey'])
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         print(f"An error occurred while retrieving allocation details: {e}")
     
     config = get_config()
@@ -564,8 +564,8 @@ def list_allocations():
             print("-" * 80)  # Print a separator line
 
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         print(f"An error occurred while retrieving allocation details: {e}")
     finally:
         cursor.close()
@@ -646,8 +646,8 @@ def list_resources():
                 total_gpu_counts[gpu_name] = total_gpu_counts.get(gpu_name, 0) + gpu_count
 
             except (KeyError, IndexError, TypeError):
-                sentry_sdk.capture_exception()
-                sentry_sdk.capture_exception()
+                
+                
                 gpu_name = "Invalid details"
                 gpu_capacity = "N/A"
                 gpu_count = "N/A"
@@ -718,8 +718,8 @@ def upload_wandb(hotkey, flag):
         run.log({"key": hotkey, "allocated": allocation_status})
         run.finish()
     except Exception as e:
-        sentry_sdk.capture_exception()
-        sentry_sdk.capture_exception()
+        
+        
         bt.logging.info(f"Error uploading to wandb : {e}")
         return
     
@@ -773,8 +773,8 @@ def main():
             if hasattr(args, 'func'):
                 args.func()
         except SystemExit:
-            sentry_sdk.capture_exception()
-            sentry_sdk.capture_exception()
+            
+            
             # Catch the SystemExit exception to prevent the script from closing
             continue
 

--- a/neurons/register.py
+++ b/neurons/register.py
@@ -18,6 +18,8 @@
 # Step 1: Import necessary libraries and modules
 
 
+import sentry_sdk
+import sentry_sdk
 import argparse
 import base64
 import os
@@ -253,6 +255,8 @@ def allocate():
                     gpu_name = str(gpu_miner['details'][0]['name']).lower()
                     break
                 except (KeyError, IndexError, TypeError):
+                    sentry_sdk.capture_exception()
+                    sentry_sdk.capture_exception()
                     gpu_name = "Invalid details"
             else:
                 gpu_name = "No details available"
@@ -312,6 +316,8 @@ def allocate_hotkey():
                 gpu_name = str(gpu_miner['details'][0]['name']).lower()
                 break
             except (KeyError, IndexError, TypeError):
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 gpu_name = "Invalid details"
         else:
             gpu_name = "No details available"
@@ -425,6 +431,8 @@ def deallocate():
             print("No allocation details found for the provided hotkey.")
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         print(f"An error occurred during de-allocation: {e}")
     finally:
         cursor.close()
@@ -466,6 +474,8 @@ def check_and_update_existing_allocations():
             public_key_list.append(info['regkey'])
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         print(f"An error occurred while retrieving allocation details: {e}")
     
     config = get_config()
@@ -554,6 +564,8 @@ def list_allocations():
             print("-" * 80)  # Print a separator line
 
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         print(f"An error occurred while retrieving allocation details: {e}")
     finally:
         cursor.close()
@@ -634,6 +646,8 @@ def list_resources():
                 total_gpu_counts[gpu_name] = total_gpu_counts.get(gpu_name, 0) + gpu_count
 
             except (KeyError, IndexError, TypeError):
+                sentry_sdk.capture_exception()
+                sentry_sdk.capture_exception()
                 gpu_name = "Invalid details"
                 gpu_capacity = "N/A"
                 gpu_count = "N/A"
@@ -704,6 +718,8 @@ def upload_wandb(hotkey, flag):
         run.log({"key": hotkey, "allocated": allocation_status})
         run.finish()
     except Exception as e:
+        sentry_sdk.capture_exception()
+        sentry_sdk.capture_exception()
         bt.logging.info(f"Error uploading to wandb : {e}")
         return
     
@@ -757,6 +773,8 @@ def main():
             if hasattr(args, 'func'):
                 args.func()
         except SystemExit:
+            sentry_sdk.capture_exception()
+            sentry_sdk.capture_exception()
             # Catch the SystemExit exception to prevent the script from closing
             continue
 

--- a/neurons/register.py
+++ b/neurons/register.py
@@ -20,6 +20,7 @@
 
 
 
+import sentry_sdk
 import argparse
 import base64
 import os
@@ -255,6 +256,7 @@ def allocate():
                     gpu_name = str(gpu_miner['details'][0]['name']).lower()
                     break
                 except (KeyError, IndexError, TypeError):
+                    sentry_sdk.capture_exception()
                     
                     
                     gpu_name = "Invalid details"
@@ -316,6 +318,7 @@ def allocate_hotkey():
                 gpu_name = str(gpu_miner['details'][0]['name']).lower()
                 break
             except (KeyError, IndexError, TypeError):
+                sentry_sdk.capture_exception()
                 
                 
                 gpu_name = "Invalid details"
@@ -431,6 +434,7 @@ def deallocate():
             print("No allocation details found for the provided hotkey.")
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         print(f"An error occurred during de-allocation: {e}")
@@ -474,6 +478,7 @@ def check_and_update_existing_allocations():
             public_key_list.append(info['regkey'])
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         print(f"An error occurred while retrieving allocation details: {e}")
@@ -564,6 +569,7 @@ def list_allocations():
             print("-" * 80)  # Print a separator line
 
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         print(f"An error occurred while retrieving allocation details: {e}")
@@ -646,6 +652,7 @@ def list_resources():
                 total_gpu_counts[gpu_name] = total_gpu_counts.get(gpu_name, 0) + gpu_count
 
             except (KeyError, IndexError, TypeError):
+                sentry_sdk.capture_exception()
                 
                 
                 gpu_name = "Invalid details"
@@ -718,6 +725,7 @@ def upload_wandb(hotkey, flag):
         run.log({"key": hotkey, "allocated": allocation_status})
         run.finish()
     except Exception as e:
+        sentry_sdk.capture_exception()
         
         
         bt.logging.info(f"Error uploading to wandb : {e}")
@@ -773,6 +781,7 @@ def main():
             if hasattr(args, 'func'):
                 args.func()
         except SystemExit:
+            sentry_sdk.capture_exception()
             
             
             # Catch the SystemExit exception to prevent the script from closing

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -16,7 +16,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-import sentry_sdk
+
 import ast
 import asyncio
 import json
@@ -257,7 +257,7 @@ class Validator:
                 try:
                     values_values = f"{float(values_values):.2f}"
                 except Exception:
-                    sentry_sdk.capture_exception()
+                    
                     pass
                 log += f" | {values_key}: {values_values}"
 
@@ -282,13 +282,13 @@ class Validator:
                     else:
                         self.stats[uid]["has_docker"] = has_docker[uid]
                 except KeyError:
-                    sentry_sdk.capture_exception()
+                    
                     self.stats[uid]["has_docker"] = False
 
                 hotkey = self.stats[uid].get("ss58_address")
                 score = calc_score(self.stats[uid], hotkey=hotkey)
             except (ValueError, KeyError):
-                sentry_sdk.capture_exception()
+                
                 score = 0
 
             self.scores[uid] = score
@@ -331,7 +331,7 @@ class Validator:
                         bt.logging.info(f"❌ Miner {uid}-{self.miners[uid]} has been deregistered. Clean up old entries.")
                         purge_miner_entries(self.db, uid, self.miners[uid])
                     except KeyError:
-                        sentry_sdk.capture_exception()
+                        
                         pass
                     bt.logging.info(f"✅ Setting up new miner {uid}-{axon.hotkey}.")
                     update_miners(self.db, [(uid, axon.hotkey)]),
@@ -354,7 +354,7 @@ class Validator:
                 else:
                     difficulty = current_difficulty
         except KeyError:
-            sentry_sdk.capture_exception()
+            
             pass
         except Exception as e:
             bt.logging.error(f"{e} => difficulty minimal: {pow_min_difficulty} attributed for {uid}")
@@ -508,7 +508,7 @@ class Validator:
                 # Read the entire content of the EXE file
                 app_data = file.read()
         except Exception as e:
-            sentry_sdk.capture_exception()
+            
             bt.logging.error(f"{e}")
             return
 
@@ -545,16 +545,16 @@ class Validator:
                         else:
                             results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                     except cryptography.fernet.InvalidToken:
-                        sentry_sdk.capture_exception()
+                        
                         bt.logging.warning(f"{queryable_for_specs_hotkey[index]} - InvalidToken")
                         results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                     except Exception as _:
-                        sentry_sdk.capture_exception()
+                        
                         traceback.print_exc()
                         results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                         
             except Exception as e:
-                sentry_sdk.capture_exception()
+                
                 traceback.print_exc()
 
         update_miner_details(self.db, list(results.keys()), list(results.values()))
@@ -656,7 +656,7 @@ class Validator:
                                         )
                                     )
                                 except KeyError:
-                                    sentry_sdk.capture_exception()
+                                    
                                     continue
 
                         for thread in self.threads:
@@ -722,13 +722,13 @@ class Validator:
 
             # If we encounter an unexpected error, log it for debugging.
             except RuntimeError as e:
-                sentry_sdk.capture_exception()
+                
                 bt.logging.error(e)
                 traceback.print_exc()
 
             # If the user interrupts the program, gracefully exit.
             except KeyboardInterrupt:
-                sentry_sdk.capture_exception()
+                
                 self.db.close()
                 bt.logging.success("Keyboard interrupt detected. Exiting validator.")
                 exit()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -17,6 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import sentry_sdk
 import ast
 import asyncio
 import json
@@ -257,6 +258,7 @@ class Validator:
                 try:
                     values_values = f"{float(values_values):.2f}"
                 except Exception:
+                    sentry_sdk.capture_exception()
                     
                     pass
                 log += f" | {values_key}: {values_values}"
@@ -282,12 +284,14 @@ class Validator:
                     else:
                         self.stats[uid]["has_docker"] = has_docker[uid]
                 except KeyError:
+                    sentry_sdk.capture_exception()
                     
                     self.stats[uid]["has_docker"] = False
 
                 hotkey = self.stats[uid].get("ss58_address")
                 score = calc_score(self.stats[uid], hotkey=hotkey)
             except (ValueError, KeyError):
+                sentry_sdk.capture_exception()
                 
                 score = 0
 
@@ -331,6 +335,7 @@ class Validator:
                         bt.logging.info(f"❌ Miner {uid}-{self.miners[uid]} has been deregistered. Clean up old entries.")
                         purge_miner_entries(self.db, uid, self.miners[uid])
                     except KeyError:
+                        sentry_sdk.capture_exception()
                         
                         pass
                     bt.logging.info(f"✅ Setting up new miner {uid}-{axon.hotkey}.")
@@ -354,6 +359,7 @@ class Validator:
                 else:
                     difficulty = current_difficulty
         except KeyError:
+            sentry_sdk.capture_exception()
             
             pass
         except Exception as e:
@@ -508,6 +514,7 @@ class Validator:
                 # Read the entire content of the EXE file
                 app_data = file.read()
         except Exception as e:
+            sentry_sdk.capture_exception()
             
             bt.logging.error(f"{e}")
             return
@@ -545,15 +552,18 @@ class Validator:
                         else:
                             results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                     except cryptography.fernet.InvalidToken:
+                        sentry_sdk.capture_exception()
                         
                         bt.logging.warning(f"{queryable_for_specs_hotkey[index]} - InvalidToken")
                         results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                     except Exception as _:
+                        sentry_sdk.capture_exception()
                         
                         traceback.print_exc()
                         results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                         
             except Exception as e:
+                sentry_sdk.capture_exception()
                 
                 traceback.print_exc()
 
@@ -656,6 +666,7 @@ class Validator:
                                         )
                                     )
                                 except KeyError:
+                                    sentry_sdk.capture_exception()
                                     
                                     continue
 
@@ -722,12 +733,14 @@ class Validator:
 
             # If we encounter an unexpected error, log it for debugging.
             except RuntimeError as e:
+                sentry_sdk.capture_exception()
                 
                 bt.logging.error(e)
                 traceback.print_exc()
 
             # If the user interrupts the program, gracefully exit.
             except KeyboardInterrupt:
+                sentry_sdk.capture_exception()
                 
                 self.db.close()
                 bt.logging.success("Keyboard interrupt detected. Exiting validator.")

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -16,6 +16,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+import sentry_sdk
 import ast
 import asyncio
 import json
@@ -29,8 +30,6 @@ from typing import Dict, Tuple, List
 import bittensor as bt
 import math
 import time
-import sentry_sdk
-
 import cryptography
 import torch
 from cryptography.fernet import Fernet
@@ -258,6 +257,7 @@ class Validator:
                 try:
                     values_values = f"{float(values_values):.2f}"
                 except Exception:
+                    sentry_sdk.capture_exception()
                     pass
                 log += f" | {values_key}: {values_values}"
 
@@ -282,11 +282,13 @@ class Validator:
                     else:
                         self.stats[uid]["has_docker"] = has_docker[uid]
                 except KeyError:
+                    sentry_sdk.capture_exception()
                     self.stats[uid]["has_docker"] = False
 
                 hotkey = self.stats[uid].get("ss58_address")
                 score = calc_score(self.stats[uid], hotkey=hotkey)
             except (ValueError, KeyError):
+                sentry_sdk.capture_exception()
                 score = 0
 
             self.scores[uid] = score
@@ -329,6 +331,7 @@ class Validator:
                         bt.logging.info(f"❌ Miner {uid}-{self.miners[uid]} has been deregistered. Clean up old entries.")
                         purge_miner_entries(self.db, uid, self.miners[uid])
                     except KeyError:
+                        sentry_sdk.capture_exception()
                         pass
                     bt.logging.info(f"✅ Setting up new miner {uid}-{axon.hotkey}.")
                     update_miners(self.db, [(uid, axon.hotkey)]),
@@ -351,6 +354,7 @@ class Validator:
                 else:
                     difficulty = current_difficulty
         except KeyError:
+            sentry_sdk.capture_exception()
             pass
         except Exception as e:
             bt.logging.error(f"{e} => difficulty minimal: {pow_min_difficulty} attributed for {uid}")
@@ -504,6 +508,7 @@ class Validator:
                 # Read the entire content of the EXE file
                 app_data = file.read()
         except Exception as e:
+            sentry_sdk.capture_exception()
             bt.logging.error(f"{e}")
             return
 
@@ -540,13 +545,16 @@ class Validator:
                         else:
                             results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                     except cryptography.fernet.InvalidToken:
+                        sentry_sdk.capture_exception()
                         bt.logging.warning(f"{queryable_for_specs_hotkey[index]} - InvalidToken")
                         results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                     except Exception as _:
+                        sentry_sdk.capture_exception()
                         traceback.print_exc()
                         results[queryable_for_specs_uid[index]] = (queryable_for_specs_hotkey[index], {})
                         
             except Exception as e:
+                sentry_sdk.capture_exception()
                 traceback.print_exc()
 
         update_miner_details(self.db, list(results.keys()), list(results.values()))
@@ -648,6 +656,7 @@ class Validator:
                                         )
                                     )
                                 except KeyError:
+                                    sentry_sdk.capture_exception()
                                     continue
 
                         for thread in self.threads:
@@ -713,11 +722,13 @@ class Validator:
 
             # If we encounter an unexpected error, log it for debugging.
             except RuntimeError as e:
+                sentry_sdk.capture_exception()
                 bt.logging.error(e)
                 traceback.print_exc()
 
             # If the user interrupts the program, gracefully exit.
             except KeyboardInterrupt:
+                sentry_sdk.capture_exception()
                 self.db.close()
                 bt.logging.success("Keyboard interrupt detected. Exiting validator.")
                 exit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ pyinstaller==6.4.0
 torch==2.1.2
 wandb==0.16.4
 pyfiglet==1.0.2
+sentry_sdk==1.44
 


### PR DESCRIPTION
This PR integrates [sentry](https://sentry.io) into the subnet's code.

Sentry is a toolkit that captures exceptions and sends all relevant information to a central server, where this information can be viewed in a dashboard. Sentry can integrate with github, so problems can be triaged, and allocated to teammembers.

![image](https://github.com/neuralinternet/compute-subnet/assets/8060851/fcb45734-79eb-4110-83ec-0b2a4e9fcd68)
![image](https://github.com/neuralinternet/compute-subnet/assets/8060851/fc8b3079-1ea2-403a-b697-58cdb6a1df95)

All except statements have been hooked, as to create a full overview what is going wrong in the codebase. This means you will get unhandled (really bad) and handled exceptions (maybe bad). The unhandled ones should be resolved first, as this is a script breaking. The handled ones allow you to see if any weird stuff is happening. If the issue is not weird at all, those events can be muted in the dashboard.

In order to get this running, you will need to create an account and create a project. AFAIK this is free. This project will give you a dsn. Both validator and miner can be started with the `--sentry-dsn <dsn>` flag. When this flag is enabled, sentry is enabled and will start sending information to the server.

You can  choose to withhold the dns and only run it in a test-net. However, if you make the dsn public, all participants in the network will report error information. This should allow you to quickly react to fatal problems and put out patches.


I have hooked all my validators in a similar fashion, but I get so many exceptions that I can't really all SN owners of the problems, so it makes more sense to have the SN owners handled this themselves.


If you feel this PR is worthy of a reward, TAO's can go to `5FZ3Cyq4wNX6rgiTD6kSEovZ6hcvcej6N3uwV68ELb6vwQo4`

Greets,
Your trusty l0lpusher69 



