### PR TITLE
feat(add docker image support): create docker file for build up docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,83 @@
+ARG CUDA_VERSION="12.4.1"
+ARG CUDA_VERSION_LOC="cuda-12.4"
+ARG OS="ubuntu22.04"
+ARG BUILD_BRANCH="main"
+
+ARG CUDA_BUILDER_IMAGE="${CUDA_VERSION}-devel-${OS}"
+ARG CUDA_RUNTIME_IMAGE="${CUDA_VERSION}-runtime-${OS}"
+ARG CUDA_BASE_IMAGE="${CUDA_VERSION}-base-${OS}"
+
+FROM nvidia/cuda:${CUDA_RUNTIME_IMAGE} as build
+
+# We need to set the host to 0.0.0.0 to allow outside access
+ENV HOST 0.0.0.0
+ENV CUDA_DOCKER_ARCH=all
+ENV HOME=/root
+
+WORKDIR /root
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+    git python3 python3-pip python3-venv \
+    build-essential wget curl \
+    ocl-icd-opencl-dev opencl-headers clinfo \
+    libclblast-dev libopenblas-dev \
+    libnvrtc-builtins11.5 libnvrtc11.2 \
+    && mkdir -p /etc/OpenCL/vendors && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd && \
+    rm -rf /var/lib/apt/list/*
+
+RUN pip3 install -U pip && pip3 install -U wheel && pip3 install -U setuptools && pip install nvidia-cuda-nvrtc-cu12
+
+# install hashcat
+RUN git clone https://github.com/hashcat/hashcat.git && \
+    cd hashcat && \
+    make install -j4 && \
+    cd ..
+
+# install SN27
+RUN git clone https://github.com/neuralinternet/Compute-Subnet.git && \
+    cd Compute-Subnet && \
+    git checkout ${BUILD_BRANCH} && \
+    python3 -m pip install --no-cache-dir -r requirements.txt && \
+    python3 -m pip install --no-cache-dir -e . && \
+    cd ..
+
+
+FROM nvidia/cuda:${CUDA_BASE_IMAGE} as base
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install --no-install-recommends --no-install-suggests -y \
+    make git python3 python3-pip python3-venv \
+    ocl-icd-opencl-dev opencl-headers clinfo \
+    libclblast-dev libopenblas-dev \
+    libnvrtc-builtins11.5 libnvrtc11.2 \
+    && mkdir -p /etc/OpenCL/vendors && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd && \
+    rm -rf /var/lib/apt/list/*
+
+# We need to set the host to 0.0.0.0 to allow outside access
+ENV HOME=/root
+ENV HOST 0.0.0.0
+ENV CUDA_DOCKER_ARCH=all
+
+ENV PATH=$PATH:/usr/local/${CUDA_VERSION_LOC}/bin
+ENV LD_LIBRARY_PATH=/usr/local/${CUDA_VERSION_LOC}/lib64;/lib/x86_64-linux-gnu;$LD_LIBRARY_PATH
+
+WORKDIR /root
+
+COPY --from=build /root /root
+
+RUN cd hashcat && make install -j4 && cd ..
+
+COPY --from=build /usr/local/lib/python3.10/dist-packages/ /usr/local/lib/python3.10/dist-packages/
+
+RUN pip3 install -U eth_utils
+
+COPY entrypoint.sh btcli /usr/local/bin/
+
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/btcli
+
+EXPOSE 8091
+
+ENTRYPOINT ["entrypoint.sh"]
+
+CMD ["/bin/bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,41 @@
+# Bittensor Subnet 27 docker for miner and validator
+
+Based on Nvidia/cuda image to build up the miner and validator
+
+The DooD (Docker outside Docker) technology was used due to DinD (Docker in Docker) container require more storage for space to include the docker.io service inside docker.  The docker image will build from latest hashcat and compute-subnet and include the CUDA and OPENCL for runing bittensor, pytorch and hashcat. Currently, the subtensor and bittensor latest version (6.12.4) are not included in order to save the image size.  
+
+Host is required to have the docker.io and NVIDIA container toolkit installed and set up. Privileged mode or [Sysbox](https://github.com/nestybox/sysbox) configured with NVIDIA GPUs are required like any other DinD/DooD container with root requirement.
+
+Rebuild Docker Image:
+	- docker image build -t sn27:latest -f Dockerfile .
+
+Run the Docker via docker compose:
+	- docker compose up -d
+
+Run the Docker via CLI:
+	- docker run --gpus all -v bittensor:/root/.bittensor -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -p 8091:8091 -e BIND_ADDR=0.0.0.0:8091 -it --privileged sn27:latest
+
+
+Configure SN27 and Run Validator or Miner:
+	- configure the WANDB and backup the key
+	 cd /root/Compute-Subnet/
+	 echo WANDB_API_KEY="your key" > .env
+	 cp .env /root/.bittensor/
+
+	- Create wallet (change the wallet name), the bittensor wallet will save to /root/.bittensor folder.
+	btcli wallet new_coldkey --wallet.name validator
+	btcli wallet new_hotkey --wallet.name validator --wallet.hotkey default
+	btcli wallet overview --wallet.name validator
+
+	- Register (change the wallet name)
+	btcli subnet register --netuid 27 --wallet.name validator --wallet.hotkey default
+
+	- Run miner 
+	cd /root/Compute-Subnet/
+	python neurons/miner.py --netuid 27 --subtensor.network finney --wallet.name miner --wallet.hotkey default --logging.debug
+
+	- Run Validator
+	cd /root/Compute-Subnet/
+	python neurons/validator.py --netuid 27 --subtensor.network finney --wallet.name validator --wallet.hotkey default --logging.debug
+
+

--- a/docker/btcli
+++ b/docker/btcli
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+import websocket
+
+import sys
+import shtab
+from bittensor import cli as btcli
+from bittensor import logging as bt_logging
+
+
+def main():
+    # Create the parser with shtab support
+    parser = btcli.__create_parser__()
+    args, unknown = parser.parse_known_args()
+
+    if args.print_completion:  # Check for print-completion argument
+        print(shtab.complete(parser, args.print_completion))
+        return
+
+    try:
+        cli_instance = btcli(args=sys.argv[1:])
+        cli_instance.run()
+    except KeyboardInterrupt:
+        print('KeyboardInterrupt')
+    except RuntimeError as e:
+        bt_logging.error(f'RuntimeError: {e}')
+    except websocket.WebSocketConnectionClosedException as e:
+        bt_logging.error(f'Subtensor related error. WebSocketConnectionClosedException: {e}')
+
+
+if __name__ == '__main__':
+    main()
+
+# The MIT License (MIT)
+# Copyright © 2021 Yuma Rao
+# Copyright © 2022 Opentensor Foundation
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation 
+# the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, 
+# and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of 
+# the Software.
+
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+# THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION 
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER 
+# DEALINGS IN THE SOFTWARE.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,38 @@
+#######################################################################
+# File name : docker-compose.yml
+# Author : Thomas Chu (05/09/2024)
+# Author email : chu_liang_han@hotmail.com
+# Project : SN27
+# Project repository : 
+# 
+# Docker-compose file of SN27
+#######################################################################
+#version: '3.5'
+name: ni
+services:
+    sn27:
+        deploy:
+            resources:
+                reservations:
+                    devices:
+                        - driver: nvidia
+                          count: all
+                          capabilities:
+                              - gpu
+        volumes:
+            - bittensor:/root/.bittensor
+            - /var/run/docker.sock:/var/run/docker.sock
+            - /usr/bin/docker:/usr/bin/docker
+        ports:
+            - 8091:8091
+        environment:
+            - BIND_ADDR=0.0.0.0:8091
+        stdin_open: true
+        tty: true
+        privileged: true
+        image: sn27:latest
+
+volumes:
+    bittensor:
+        external: true
+        name: bittensor

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Start docker
+# start-docker.sh
+cp /root/.bittensor/.env /root/Compute-Subnet/.env
+
+# Execute specified command
+"$@"


### PR DESCRIPTION
# Bittensor Subnet 27 docker for miner, validator, and CI/CD operations

Based on Nvidia/cuda image to build up the miner and validator

The DooD (Docker outside Docker) technology was used due to DinD (Docker in Docker) container require more storage for space to include the docker.io service inside docker.  The docker image will build from latest hashcat and compute-subnet and include the CUDA and OPENCL for runing bittensor, pytorch and hashcat. Currently, the subtensor and bittensor latest version (6.12.4) are not included in order to save the image size.  

The host is required to have the docker.io and NVIDIA container toolkit installed and set up. Privileged mode or [Sysbox](https://github.com/nestybox/sysbox) configured with NVIDIA GPUs are required like any other DinD/DooD container with root requirements.

Rebuild Docker Image:
	- docker image build -t sn27:latest -f Dockerfile .

Run the Docker via docker compose:
	- docker compose up -d

Run the Docker via CLI:
	- docker run --gpus all -v bittensor:/root/.bittensor -v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -p 8091:8091 -e BIND_ADDR=0.0.0.0:8091 -it --privileged sn27:latest


Configure SN27 and Run Validator or Miner:
	- configure the WANDB and backup the key
	 cd /root/Compute-Subnet/
	 echo WANDB_API_KEY="your key" > .env
	 cp .env /root/.bittensor/

	- Create wallet (change the wallet name), the bittensor wallet will save to /root/.bittensor folder.
	btcli wallet new_coldkey --wallet.name validator
	btcli wallet new_hotkey --wallet.name validator --wallet.hotkey default
	btcli wallet overview --wallet.name validator

	- Register (change the wallet name)
	btcli subnet register --netuid 27 --wallet.name validator --wallet.hotkey default

	- Run miner 
	cd /root/Compute-Subnet/
	python neurons/miner.py --netuid 27 --subtensor.network finney --wallet.name miner --wallet.hotkey default --logging.debug

	- Run Validator
	cd /root/Compute-Subnet/
	python neurons/validator.py --netuid 27 --subtensor.network finney --wallet.name validator --wallet.hotkey default --logging.debug


