### PR TITLE
add a check logic to see if the allocated details is a part of the offline keys list before return

### DIFF
--- a/neurons/register_api.py
+++ b/neurons/register_api.py
@@ -1299,7 +1299,8 @@ class RegisterAPI:
                     )
                     entry.uuid_key = info["uuid"]
                     entry.ssh_key = info["ssh_key"]
-                    allocation_list.append(entry)
+                    if hotkey not in self.checking_allocated:
+                        allocation_list.append(entry)
 
             except Exception as e:
                 bt.logging.error(


### PR DESCRIPTION
Ticket CZN-256.

Issue: 
the list resources API return the offline resources. while it shouldn't. 

solution: 
just checking the list of the offline hotkeys to make sure it is not part of it.