### PR TITLE
fix: disable miner port check

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.4.9"
+__version__ = "1.5.0"
 __minimal_miner_version__ = "1.4.9"
-__minimal_validator_version__ = "1.4.9"
+__minimal_validator_version__ = "1.5.0"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -838,7 +838,7 @@ class Validator:
                         # Filter axons with stake and ip address.
                         self._queryable_uids = self.get_queryable()
 
-                        self.sync_checklist()
+                        #self.sync_checklist()
 
                     if self.current_block % block_next_sync_status == 0 or block_next_sync_status < self.current_block:
                         block_next_sync_status = self.current_block + 25  # ~ every 5 minutes


### PR DESCRIPTION
**Disabling of Feature**: Miner Port Check
**Reason**: The check for miner ports and allocations, combined with updating lists in WandB, caused excessive load on the WandB API, resulting in a failure of the dependent feature.
**Action**: The feature has been disabled, which poses no issue as it is not currently in use for any validation purposes.