### PR TITLE
fix: score calculation after de-allocation

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.5.0"
-__minimal_miner_version__ = "1.4.9"
-__minimal_validator_version__ = "1.5.0"
+__version__ = "1.5.1"
+__minimal_miner_version__ = "1.5.1"
+__minimal_validator_version__ = "1.5.1"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.5.1"
+__version__ = "1.5.2"
 __minimal_miner_version__ = "1.5.1"
-__minimal_validator_version__ = "1.5.1"
+__minimal_validator_version__ = "1.5.2"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/neurons/Validator/calculate_pow_score.py
+++ b/neurons/Validator/calculate_pow_score.py
@@ -53,11 +53,11 @@ def calc_score(response, hotkey, allocated_hotkeys, penalized_hotkeys, validator
     :return:
     """
     try:
-        challenge_attempts = prevent_none(response["challenge_attempts"])
-        challenge_successes = prevent_none(response["challenge_successes"])
-        last_20_challenge_failed = prevent_none(response["last_20_challenge_failed"])
-        challenge_elapsed_time_avg = prevent_none(response["challenge_elapsed_time_avg"])
-        challenge_difficulty_avg = prevent_none(response["last_20_difficulty_avg"])
+        challenge_attempts = prevent_none(response.get("challenge_attempts",1))
+        challenge_successes = prevent_none(response.get("challenge_successes",0))
+        last_20_challenge_failed = prevent_none(response.get("last_20_challenge_failed",0))
+        challenge_elapsed_time_avg = prevent_none(response.get("challenge_elapsed_time_avg", compute.pow_timeout))
+        challenge_difficulty_avg = prevent_none(response.get("last_20_difficulty_avg", compute.pow_min_difficulty))
         has_docker = response.get("has_docker", False)
 
         # Define base weights for the PoW

--- a/neurons/Validator/database/challenge.py
+++ b/neurons/Validator/database/challenge.py
@@ -37,6 +37,7 @@ def select_challenge_stats(db: ComputeDb) -> dict:
         }
     """
     cursor = db.get_cursor()
+
     cursor.execute(
         """
 WITH RankedChallenges AS (SELECT uid,
@@ -61,8 +62,10 @@ FROM (SELECT uid,
              SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END)     AS challenge_successes,
              AVG(CASE WHEN success = 1 THEN elapsed_time END) AS challenge_elapsed_time_avg,
              AVG(CASE WHEN success = 1 THEN difficulty END)   AS challenge_difficulty_avg
-      FROM challenge_details
-      WHERE date(created_at) >= date('now', '-12 hours')
+      FROM (SELECT *
+            FROM challenge_details
+            ORDER BY created_at DESC
+            LIMIT 50) AS latest_entries
       GROUP BY uid, ss58_address) AS main_query
          LEFT JOIN (SELECT uid,
                            ss58_address,

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -656,18 +656,18 @@ class Miner:
                     self.sync_status()
 
                     # Check port open
-                    port = int(self.config.ssh.port)
-                    if port:
-                        result = check_port('localhost', port)
-                        if result is True:
-                            bt.logging.info(f"API: Port {port} on the server is open")
-                        elif result is False:
-                            bt.logging.info(f"API: Port {port} on the server is closed")
-                        else:
-                            bt.logging.warning(f"API: Could not determine status of port {port} on the server")
-                    else:
-                        bt.logging.warning(f"API: Could not find the server port that was provided to validator")
-                    self.wandb.update_miner_port_open(result)
+                    # port = int(self.config.ssh.port)
+                    # if port:
+                    #     result = check_port('localhost', port)
+                    #     if result is True:
+                    #         bt.logging.info(f"API: Port {port} on the server is open")
+                    #     elif result is False:
+                    #         bt.logging.info(f"API: Port {port} on the server is closed")
+                    #     else:
+                    #         bt.logging.warning(f"API: Could not determine status of port {port} on the server")
+                    # else:
+                    #     bt.logging.warning(f"API: Could not find the server port that was provided to validator")
+                    # self.wandb.update_miner_port_open(result)
                     
                     # check allocation status
                     self.__check_alloaction_errors()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -292,11 +292,17 @@ class Validator:
 
         self.pretty_print_dict_values(self.stats)
 
+        self._queryable_uids = self.get_queryable()
+
         # Calculate score
         for uid in self.uids:
             try:
-                # Determine if the user's hotkey has Docker
-                hotkey = self.stats[uid].get("ss58_address")
+                axon = self._queryable_uids[uid]
+                hotkey = axon.hotkey
+
+                if uid not in self.stats:
+                    self.stats[uid] = {}  # Initialize empty dictionary for this UID
+
                 if hotkey in has_docker_hotkeys:
                     self.stats[uid]["has_docker"] = True
                 elif not self.finalized_specs_once:
@@ -304,22 +310,14 @@ class Validator:
                 else:
                     self.stats[uid]["has_docker"] = False
 
-                # Find the maximum score of all uids excluding allocated uids
-                # max_score_uids = max(
-                #     self.stats[uid]["score"]
-                #     for uid in self.stats
-                #     if "score" in self.stats[uid] and self.stats[uid].get("ss58_address") not in self.allocated_hotkeys
-                # )
-
-                # score = calc_score(self.stats[uid], hotkey=hotkey, allocated_hotkeys=self.allocated_hotkeys, max_score_uid=max_score_uids)
-                score = calc_score(self.stats[uid],
-                                    hotkey = hotkey,
-                                    allocated_hotkeys = self.allocated_hotkeys,
-                                    penalized_hotkeys = self.penalized_hotkeys,
-                                    validator_hotkeys = valid_validator_hotkeys)
-
+                score = calc_score(self.stats[uid], hotkey, self.allocated_hotkeys, self.penalized_hotkeys, valid_validator_hotkeys)
                 self.stats[uid]["score"] = score
-            except (ValueError, KeyError):
+
+            except KeyError as e:
+                # bt.logging.info(f"KeyError occurred for UID {uid}: {str(e)}")
+                score = 0
+            except Exception as e:
+                # bt.logging.info(f"An unexpected exception occurred for UID {uid}: {str(e)}")
                 score = 0
 
             self.scores[uid] = score


### PR DESCRIPTION
- Updated version numbers in compute/__init__.py
- Enhanced error handling and resilience in calculate_pow_score.py by using default values with the .get() method.
- Updated SQL queries in challenge.py to retrieve the last 60 entries per UID instead of filtering by the last 12 hours.
- Removed redundant SSH port checks and logging.
- Improved score synchronization and error handling in validator.py.