### PR TITLE
Hotfix: Fix score calculation after de-allocation

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.4.9"
+__version__ = "1.5.0"
 __minimal_miner_version__ = "1.4.9"
-__minimal_validator_version__ = "1.4.9"
+__minimal_validator_version__ = "1.5.0"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.5.0"
-__minimal_miner_version__ = "1.4.9"
-__minimal_validator_version__ = "1.5.0"
+__version__ = "1.5.2"
+__minimal_miner_version__ = "1.5.1"
+__minimal_validator_version__ = "1.5.2"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/neurons/Validator/calculate_pow_score.py
+++ b/neurons/Validator/calculate_pow_score.py
@@ -53,11 +53,11 @@ def calc_score(response, hotkey, allocated_hotkeys, penalized_hotkeys, validator
     :return:
     """
     try:
-        challenge_attempts = prevent_none(response["challenge_attempts"])
-        challenge_successes = prevent_none(response["challenge_successes"])
-        last_20_challenge_failed = prevent_none(response["last_20_challenge_failed"])
-        challenge_elapsed_time_avg = prevent_none(response["challenge_elapsed_time_avg"])
-        challenge_difficulty_avg = prevent_none(response["last_20_difficulty_avg"])
+        challenge_attempts = prevent_none(response.get("challenge_attempts",1))
+        challenge_successes = prevent_none(response.get("challenge_successes",0))
+        last_20_challenge_failed = prevent_none(response.get("last_20_challenge_failed",0))
+        challenge_elapsed_time_avg = prevent_none(response.get("challenge_elapsed_time_avg", compute.pow_timeout))
+        challenge_difficulty_avg = prevent_none(response.get("last_20_difficulty_avg", compute.pow_min_difficulty))
         has_docker = response.get("has_docker", False)
 
         # Define base weights for the PoW

--- a/neurons/Validator/database/challenge.py
+++ b/neurons/Validator/database/challenge.py
@@ -37,56 +37,61 @@ def select_challenge_stats(db: ComputeDb) -> dict:
         }
     """
     cursor = db.get_cursor()
+
     cursor.execute(
         """
-WITH RankedChallenges AS (SELECT uid,
-                                 ss58_address,
-                                 success,
-                                 created_at,
-                                 ROW_NUMBER() OVER (PARTITION BY uid, ss58_address ORDER BY created_at DESC) AS row_num
-                          FROM challenge_details)
-SELECT main_query.uid,
-       main_query.ss58_address,
-       main_query.challenge_attempts,
-       main_query.challenge_successes,
-       main_query.challenge_elapsed_time_avg,
-       main_query.challenge_difficulty_avg,
-       COALESCE(main_query.challenge_failed, 0) as challenge_failed,
-       COALESCE(last_20_challenge_failed.last_20_challenge_failed, 0) as last_20_challenge_failed,
-       last_20_query.last_20_difficulty_avg
-FROM (SELECT uid,
-             ss58_address,
-             COUNT(*)                                         AS challenge_attempts,
-             COUNT(CASE WHEN success = 0 THEN 1 END)          AS challenge_failed,
-             SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END)     AS challenge_successes,
-             AVG(CASE WHEN success = 1 THEN elapsed_time END) AS challenge_elapsed_time_avg,
-             AVG(CASE WHEN success = 1 THEN difficulty END)   AS challenge_difficulty_avg
-      FROM challenge_details
-      WHERE date(created_at) >= date('now', '-12 hours')
-      GROUP BY uid, ss58_address) AS main_query
-         LEFT JOIN (SELECT uid,
-                           ss58_address,
-                           COUNT(*) AS last_20_challenge_failed
-                    FROM (SELECT uid, ss58_address, success
-                          FROM RankedChallenges
-                          WHERE row_num <= 20
-                          ORDER BY created_at DESC) AS Last20Rows
-                    WHERE success = 0
-                    GROUP BY uid, ss58_address) AS last_20_challenge_failed
+        WITH RankedChallenges AS (
+            SELECT uid,
+                   ss58_address,
+                   success,
+                   elapsed_time,
+                   difficulty,
+                   created_at,
+                   ROW_NUMBER() OVER (PARTITION BY uid ORDER BY created_at DESC) AS row_num
+            FROM challenge_details
+        ),
+        FilteredChallenges AS (
+            SELECT *
+            FROM RankedChallenges
+            WHERE row_num <= 60
+        )
+        SELECT main_query.uid,
+               main_query.ss58_address,
+               COUNT(*)                                         AS challenge_attempts,
+               COUNT(CASE WHEN success = 0 THEN 1 END)          AS challenge_failed,
+               SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END)     AS challenge_successes,
+               AVG(CASE WHEN success = 1 THEN elapsed_time END) AS challenge_elapsed_time_avg,
+               AVG(CASE WHEN success = 1 THEN difficulty END)   AS challenge_difficulty_avg,
+               COALESCE(last_20_challenge_failed.last_20_challenge_failed, 0) as last_20_challenge_failed,
+               last_20_query.last_20_difficulty_avg
+        FROM (SELECT *
+              FROM FilteredChallenges
+              ORDER BY created_at DESC) AS main_query
+             LEFT JOIN (SELECT uid,
+                               ss58_address,
+                               COUNT(*) AS last_20_challenge_failed
+                        FROM (SELECT uid,
+                                     ss58_address,
+                                     success,
+                                     ROW_NUMBER() OVER (PARTITION BY uid ORDER BY created_at DESC) AS row_num
+                              FROM challenge_details)
+                        WHERE row_num <= 20 AND success = 0
+                        GROUP BY uid, ss58_address) AS last_20_challenge_failed
                    ON main_query.uid = last_20_challenge_failed.uid AND
                       main_query.ss58_address = last_20_challenge_failed.ss58_address
-         LEFT JOIN (SELECT uid,
-                           ss58_address,
-                           AVG(difficulty) AS last_20_difficulty_avg
-                    FROM (SELECT uid,
-                                 ss58_address,
-                                 difficulty,
-                                 ROW_NUMBER() OVER (PARTITION BY uid, ss58_address ORDER BY created_at DESC) AS row_num
-                          FROM challenge_details
-                          WHERE success = 1) AS subquery
-                    WHERE row_num <= 20
-                    GROUP BY uid, ss58_address) AS last_20_query
-                   ON main_query.uid = last_20_query.uid AND main_query.ss58_address = last_20_query.ss58_address;
+             LEFT JOIN (SELECT uid,
+                               ss58_address,
+                               AVG(difficulty) AS last_20_difficulty_avg
+                        FROM (SELECT uid,
+                                     ss58_address,
+                                     difficulty,
+                                     ROW_NUMBER() OVER (PARTITION BY uid ORDER BY created_at DESC) AS row_num
+                              FROM challenge_details
+                              WHERE success = 1)
+                        WHERE row_num <= 20
+                        GROUP BY uid, ss58_address) AS last_20_query
+                   ON main_query.uid = last_20_query.uid AND main_query.ss58_address = last_20_query.ss58_address
+        GROUP BY main_query.uid, main_query.ss58_address;
         """
     )
 
@@ -98,18 +103,18 @@ FROM (SELECT uid,
             uid,
             ss58_address,
             challenge_attempts,
+            challenge_failed,
             challenge_successes,
             challenge_elapsed_time_avg,
             challenge_difficulty_avg,
-            challenge_failed,
             last_20_challenge_failed,
             last_20_difficulty_avg,
         ) = result
         stats[uid] = {
             "ss58_address": ss58_address,
             "challenge_attempts": challenge_attempts,
-            "challenge_successes": challenge_successes,
             "challenge_failed": int(challenge_failed) if challenge_failed else 0,
+            "challenge_successes": challenge_successes,
             "challenge_elapsed_time_avg": challenge_elapsed_time_avg,
             "challenge_difficulty_avg": challenge_difficulty_avg,
             "last_20_challenge_failed": last_20_challenge_failed,

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -656,18 +656,18 @@ class Miner:
                     self.sync_status()
 
                     # Check port open
-                    port = int(self.config.ssh.port)
-                    if port:
-                        result = check_port('localhost', port)
-                        if result is True:
-                            bt.logging.info(f"API: Port {port} on the server is open")
-                        elif result is False:
-                            bt.logging.info(f"API: Port {port} on the server is closed")
-                        else:
-                            bt.logging.warning(f"API: Could not determine status of port {port} on the server")
-                    else:
-                        bt.logging.warning(f"API: Could not find the server port that was provided to validator")
-                    self.wandb.update_miner_port_open(result)
+                    # port = int(self.config.ssh.port)
+                    # if port:
+                    #     result = check_port('localhost', port)
+                    #     if result is True:
+                    #         bt.logging.info(f"API: Port {port} on the server is open")
+                    #     elif result is False:
+                    #         bt.logging.info(f"API: Port {port} on the server is closed")
+                    #     else:
+                    #         bt.logging.warning(f"API: Could not determine status of port {port} on the server")
+                    # else:
+                    #     bt.logging.warning(f"API: Could not find the server port that was provided to validator")
+                    # self.wandb.update_miner_port_open(result)
                     
                     # check allocation status
                     self.__check_alloaction_errors()

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -92,8 +92,6 @@ class Miner:
 
     miner_http_server: TCPServer
 
-
-
     _axon: bt.axon
 
     @property
@@ -185,6 +183,20 @@ class Miner:
         self.wandb.update_specs()
 
         # check allocation status
+        self.__check_alloaction_errors()
+
+        # Disable the Spec request and replaced with WanDB
+        # self.request_specs_processor = RequestSpecsProcessor()
+
+        self.last_updated_block = self.current_block - (self.current_block % 100)
+        self.allocate_action = False
+
+        # if (
+        #     not self.wandb.sync_allocated(self.wallet.hotkey.ss58_address)
+        #     or not allocation_key_encoded
+        # ):
+        # self.miner_http_server = start_server(self.config.ssh.port)
+    def __check_alloaction_errors(self):
         file_path = "allocation_key"
         allocation_key_encoded = None
         if os.path.exists(file_path):
@@ -210,19 +222,6 @@ class Miner:
                 bt.logging.info(
                     "Container is already running without allocated. Killing the container."
                 )
-
-        # Disable the Spec request and replaced with WanDB
-        # self.request_specs_processor = RequestSpecsProcessor()
-
-        self.last_updated_block = self.current_block - (self.current_block % 100)
-        self.allocate_action = False
-
-        if (
-            not self.wandb.sync_allocated(self.wallet.hotkey.ss58_address)
-            or not allocation_key_encoded
-        ):
-            self.miner_http_server = start_server(self.config.ssh.port)
-
     def init_axon(self):
         # Step 6: Build and link miner functions to the axon.
         # The axon handles request processing, allowing validators to send this process requests.
@@ -472,7 +471,7 @@ class Miner:
                 if timeline > 0:
                     if self.allocate_action == False:
                         self.allocate_action = True
-                        stop_server(self.miner_http_server)
+                        # stop_server(self.miner_http_server)
                         result = register_allocation(timeline, device_requirement, public_key, docker_requirement)
                         self.allocate_action = False
                         synapse.output = result
@@ -481,7 +480,7 @@ class Miner:
                         synapse.output = {"status": False}
                 else:
                     result = deregister_allocation(public_key)
-                    self.miner_http_server = start_server(self.config.ssh.port)
+                    # self.miner_http_server = start_server(self.config.ssh.port)
                 synapse.output = result
         self.update_allocation(synapse)
         synapse.output["port"] = int(self.config.ssh.port)
@@ -669,6 +668,9 @@ class Miner:
                     else:
                         bt.logging.warning(f"API: Could not find the server port that was provided to validator")
                     self.wandb.update_miner_port_open(result)
+                    
+                    # check allocation status
+                    self.__check_alloaction_errors()
 
                     # Log chain data to wandb
                     chain_data = {

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -186,6 +186,7 @@ class Miner:
 
         # check allocation status
         file_path = "allocation_key"
+        allocation_key_encoded = None
         if os.path.exists(file_path):
             # Open the file in read mode ('r') and read the data
             with open(file_path, "r") as file:

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -356,9 +356,25 @@ class Validator:
         current_version = __version_as_int__
         if subnet_prometheus_version != current_version:
             self.init_prometheus(force_update=True)
+    def remove_duplicate_penalized_hotkeys(self):
+        """
+        Removes any duplicate entries in the penalized_hotkeys_checklist
+        based on the 'hotkey' field.
+        """
+        seen = set()
+        unique_penalized_list = []
+
+        for item in self.penalized_hotkeys_checklist:
+            if item['hotkey'] not in seen:
+                unique_penalized_list.append(item)
+                seen.add(item['hotkey'])
+
+        self.penalized_hotkeys_checklist = unique_penalized_list
+        bt.logging.info("Removed duplicate hotkeys from penalized_hotkeys_checklist.")
 
     def sync_checklist(self):
         self.threads = []
+        self.penalized_hotkeys_checklist = self.wandb.get_penalized_hotkeys_checklist(self.get_valid_validator_hotkeys(), True)
         for i in range(0, len(self.uids), self.validator_challenge_batch_size):
             for _uid in self.uids[i : i + self.validator_challenge_batch_size]:
                 try:
@@ -373,12 +389,15 @@ class Validator:
                     )
                 except KeyError:
                     continue
+        self.remove_duplicate_penalized_hotkeys()
 
         for thread in self.threads:
             thread.start()
-        
+
         for thread in self.threads:
             thread.join()
+
+        self.wandb.update_penalized_hotkeys_checklist(self.penalized_hotkeys_checklist)
 
     def sync_miners_info(self, queryable_tuple_uids_axons: List[Tuple[int, bt.AxonInfo]]):
         if queryable_tuple_uids_axons:
@@ -566,45 +585,46 @@ class Validator:
         response = dendrite.query(axon, Allocate(timeline=1, checking=True), timeout=30)
         port = response.get("port", "")
         status = response.get("status", False)
-
+        checklist_hotkeys = [item['hotkey'] for item in self.penalized_hotkeys_checklist]
         if port:
-            is_port_open = check_port(axon.ip, port)
-            penalized_hotkeys_checklist = self.wandb.get_penalized_hotkeys_checklist(self.get_valid_validator_hotkeys(), True)
-            checklist_hotkeys = [item['hotkey'] for item in penalized_hotkeys_checklist]
-
-            if is_port_open:
+            if not status:
+                is_port_open = check_port(axon.ip, port)
+                if (axon.hotkey not in checklist_hotkeys )and (not is_port_open):
+                    self.penalized_hotkeys_checklist.append({"hotkey": axon.hotkey, "status_code": "PORT_CLOSED", "description": "The port of ssh server is closed"})
+                    bt.logging.info(
+                        f"Debug {Allocate.__name__} - status of Checking allocation - {status} {uid} - Port is closed and not usable, even though it has been allocated."
+                    )
+                else:
+                    bt.logging.info(f"Debug {Allocate.__name__} - status of Checking allocation - {status} {uid} - Port is open and the miner is allocated")
+            else:
                 is_ssh_access = True
-                bt.logging.info(f"Debug {Allocate.__name__} - status of Checking allocation - {status} {uid}")
-                if status is True: # if it's able to check allocation
-                    private_key, public_key = rsa.generate_key_pair()
-                    device_requirement = {"cpu": {"count": 1}, "gpu": {}, "hard_disk": {"capacity": 1073741824}, "ram": {"capacity": 1073741824}}
-                    
-                    try:
-                        response = dendrite.query(axon, Allocate(timeline=1, device_requirement=device_requirement, checking=False, public_key=public_key), timeout=60)
-                        if response and response["status"] is True:
-                            bt.logging.info(f"Debug {Allocate.__name__} - Successfully Allocated - {uid}")
-                            private_key = private_key.encode("utf-8")
-                            decrypted_info_str = rsa.decrypt_data(private_key, base64.b64decode(response["info"]))
-                            info = json.loads(decrypted_info_str)
-                            is_ssh_access = check_ssh_login(axon.ip, port, info['username'], info['password'])
-                    except Exception as e:
-                        bt.logging.error(f"{e}")
-                        return
-
+                allocation_status = False
+                private_key, public_key = rsa.generate_key_pair()
+                device_requirement = {"cpu": {"count": 1}, "gpu": {}, "hard_disk": {"capacity": 1073741824}, "ram": {"capacity": 1073741824}}
+                try:
+                    response = dendrite.query(axon, Allocate(timeline=1, device_requirement=device_requirement, checking=False, public_key=public_key), timeout=60)
+                    if response and response["status"] is True:
+                        allocation_status = True
+                        bt.logging.info(f"Debug {Allocate.__name__} - Successfully Allocated - {uid}")
+                        private_key = private_key.encode("utf-8")
+                        decrypted_info_str = rsa.decrypt_data(private_key, base64.b64decode(response["info"]))
+                        info = json.loads(decrypted_info_str)
+                        is_ssh_access = check_ssh_login(axon.ip, port, info['username'], info['password'])
+                except Exception as e:
+                    bt.logging.error(f"{e}")
+                while True and allocation_status:
                     deregister_response = dendrite.query(axon, Allocate(timeline=0, checking=False, public_key=public_key), timeout=60)
                     if deregister_response and deregister_response["status"] is True:
                         bt.logging.info(f"Debug {Allocate.__name__} - Deallocated - {uid}")
-
-
+                        break
+                    else:
+                        bt.logging.error(f"Debug {Allocate.__name__} - Failed to deallocate - {uid} will retry in 5 seconds")
+                        time.sleep(5)
                 if axon.hotkey in checklist_hotkeys:
-                    penalized_hotkeys_checklist = [item for item in penalized_hotkeys_checklist if item['hotkey'] != axon.hotkey]
+                    self.penalized_hotkeys_checklist = [item for item in self.penalized_hotkeys_checklist if item['hotkey'] != axon.hotkey]
                 if not is_ssh_access:
-                    penalized_hotkeys_checklist.append({"hotkey": axon.hotkey, "status_code": "SSH_ACCESS_DISABLED", "description": "It can not access to the server via ssh"})           
-            else:
-                if axon.hotkey not in checklist_hotkeys:
-                    penalized_hotkeys_checklist.append({"hotkey": axon.hotkey, "status_code": "PORT_CLOSED", "description": "The port of ssh server is closed"})
-
-            self.wandb.update_penalized_hotkeys_checklist(penalized_hotkeys_checklist)
+                    bt.logging.info(f"Debug {Allocate.__name__} - status of Checking allocation - {status} {uid} - SSH access is disabled")
+                    self.penalized_hotkeys_checklist.append({"hotkey": axon.hotkey, "status_code": "SSH_ACCESS_DISABLED", "description": "It can not access to the server via ssh"})               
 
     def execute_specs_request(self):
         if len(self.queryable_for_specs) > 0:
@@ -686,11 +706,11 @@ class Validator:
             bt.logging.info(f"{hotkey} - {specs}")
         """
         self.finalized_specs_once = True
-    
+
     def get_specs_wandb(self):
 
         bt.logging.info(f"💻 Hardware list of uids queried (Wandb): {list(self._queryable_uids.keys())}")
-     
+
         specs_dict = self.wandb.get_miner_specs(self._queryable_uids) 
         # Update the local db with the data from wandb
         update_miner_details(self.db, list(specs_dict.keys()), list(specs_dict.values()))


### PR DESCRIPTION
• Updated version numbers in compute/init.py
• Enhanced error handling and resilience in calculate_pow_score.py by using default values with the .get() method.
• Updated SQL queries in challenge.py to retrieve the last 60 entries per UID instead of filtering by the last 12 hours.
• Removed redundant SSH port checks and logging.
• Improved score synchronization and error handling in validator.py.