### PR TITLE
feat: Add online status to Allocation in RegisterAPI

### DIFF
--- a/neurons/register_api.py
+++ b/neurons/register_api.py
@@ -107,6 +107,7 @@ class Allocation(BaseModel):
     ssh_username: str = ""
     ssh_password: str = ""
     ssh_command: str = ""
+    status: str = ""
     ssh_key: str = ""
     uuid_key: str = ""
 
@@ -1296,6 +1297,12 @@ class RegisterAPI:
                     )
                     entry.uuid_key = info["uuid"]
                     entry.ssh_key = info["ssh_key"]
+                    # check the online status in self.checking_allocated
+                    entry.status = "online"
+                    for item in self.checking_allocated:
+                        if item.get("hotkey") == hotkey:
+                            entry.status = offline
+                            break
                     allocation_list.append(entry)
 
             except Exception as e:


### PR DESCRIPTION
This commit adds a new attribute "status" to the Allocation class in RegisterAPI. The "status" attribute is used to track the online status of an allocation. In the code changes, the "status" attribute is set to "online" for each allocation entry. Additionally, a check is performed in the "checking_allocated" list to update the "status" attribute to "offline" if a matching hotkey is found.