### PR TITLE
Feat/csn 294 build out codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "feat/csn-294-build-out-codeql" ]
+    branches: [ "dev" ]
   pull_request:
-    branches: [ "feat/csn-294-build-out-codeql" ]
+    branches: [ "dev" ]
   schedule:
     - cron: '22 6 * * 5'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
-
+          python-version: '3.10'
+  
       - name: Cache Python dependencies
         uses: actions/cache@v3
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "dev", "main" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "dev", "main" ]
   schedule:
     - cron: '22 6 * * 5'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,8 +63,9 @@ jobs:
 
       - name: Install dependencies
         # NOTE: This step checks if a requirements.txt file exists before installing.
-        if: fileExists('requirements.txt')
+        if: ${{ hashFiles('**/requirements.txt') != '' }}
         run: pip install --upgrade pip && pip install -r requirements.txt
+
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "feat/csn 294 build out codeql" ]
+    branches: [ "feat/csn-294-build-out-codeql" ]
   pull_request:
-    branches: [ "feat/csn 294 build out codeql" ]
+    branches: [ "feat/csn-294-build-out-codeql" ]
   schedule:
     - cron: '22 6 * * 5'
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,105 @@
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: [ "feat/csn 294 build out codeql" ]
+  pull_request:
+    branches: [ "feat/csn 294 build out codeql" ]
+  schedule:
+    - cron: '22 6 * * 5'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+        # CodeQL supports the following values for 'language': 
+        # 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # If analyzing a compiled language, you can modify the 'build-mode' (e.g. `full` or `manual`).
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # NOTE: The following steps are optional if you have a Python project
+      # with dependencies. This sets up Python and caches dependencies to speed up future analyses.
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Cache Python dependencies
+        uses: actions/cache@v3
+        with:
+          # NOTE: Adjust the path and key if your dependencies are stored elsewhere.
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        # NOTE: This step checks if a requirements.txt file exists before installing.
+        if: fileExists('requirements.txt')
+        run: pip install --upgrade pip && pip install -r requirements.txt
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          #
+          # For more details on CodeQL's query packs, refer to:
+          # https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          #
+          # NOTE: Enabling security-extended and security-and-quality queries can provide more comprehensive analysis.
+          queries: security-extended,security-and-quality
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above
+      # to set the build mode to "manual" for that language. Then modify this step
+      # to build your code.
+      #
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      - if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This will add CodeQL security checks and essentially a DevSecOps pipeline to the repo for deeper security analysis. It is non breaking to the compute subnet code, and only triggers GitHub Actions to run a CodeQL image to check the code. 

This directory (.github/workflows/) that has been created with the actions file is standard and can be found in most open source projects. 