### PR TITLE
fix: ensure python3 points to conda Python in non-interactive SSH sessions

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.6.1"
+__version__ = "1.6.2"
 __minimal_miner_version__ = "1.6.0"
-__minimal_validator_version__ = "1.6.0"
+__minimal_validator_version__ = "1.6.1"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))


### PR DESCRIPTION
The POG script fails with ModuleNotFoundError because, as under non-interactive SSH sessions, python3 points to a different (system) Python rather than the conda Python that has PyTorch installed.
