### PR TITLE
chore: quick fix for allocate without ssh considered as test

### DIFF
--- a/neurons/Miner/allocate.py
+++ b/neurons/Miner/allocate.py
@@ -37,6 +37,7 @@ def register_allocation(timeline, device_requirement, public_key, docker_require
             cpu_assignment = "0"
         ram_capacity = device_requirement["ram"]["capacity"]  # e.g 5g
         hard_disk_capacity = device_requirement["hard_disk"]["capacity"]  # e.g 100g
+        testing = device_requirement.get("testing", False)
         if not device_requirement["gpu"]:
             gpu_capacity = 0
         else:
@@ -47,7 +48,7 @@ def register_allocation(timeline, device_requirement, public_key, docker_require
         ram_usage = {"capacity": str(int(ram_capacity / 1073741824)) + "g"}
         hard_disk_usage = {"capacity": str(int(hard_disk_capacity / 1073741824)) + "g"}
 
-        run_status = run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, docker_requirement)
+        run_status = run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, docker_requirement, testing)
 
         if run_status["status"]:
             bt.logging.info("Successfully allocated container.")

--- a/neurons/Miner/container.py
+++ b/neurons/Miner/container.py
@@ -96,7 +96,7 @@ def kill_container():
         return False
 
 # Run a new docker container with the given docker_name, image_name and device information
-def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, docker_requirement: dict):
+def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, docker_requirement: dict,testing: bool):
     try:
         client, containers = get_docker()
         # Configuration
@@ -172,7 +172,7 @@ def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, 
         # client.volumes.create(volume_name, driver = 'local', driver_opts={'size': hard_disk_capacity})
 
         # Determine container name based on ssh key
-        container_to_run = container_name if docker_ssh_key else container_name_test
+        container_to_run = container_name_test if testing else container_name
 
         # Step 2: Run the Docker container
         device_requests = [DeviceRequest(count=-1, capabilities=[["gpu"]])]

--- a/neurons/Miner/container.py
+++ b/neurons/Miner/container.py
@@ -96,7 +96,7 @@ def kill_container():
         return False
 
 # Run a new docker container with the given docker_name, image_name and device information
-def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, docker_requirement: dict,testing: bool):
+def run_container(cpu_usage, ram_usage, hard_disk_usage, gpu_usage, public_key, docker_requirement: dict, testing: bool):
     try:
         client, containers = get_docker()
         # Configuration

--- a/neurons/miner_checker.py
+++ b/neurons/miner_checker.py
@@ -91,7 +91,7 @@ class MinerChecker:
         allocation_status = False 
         private_key, public_key = rsa.generate_key_pair() 
 
-        device_requirement = {"cpu": {"count": 1}, "gpu": {}, "hard_disk": {"capacity": 1073741824}, "ram": {"capacity": 1073741824}}
+        device_requirement = {"cpu": {"count": 1}, "gpu": {}, "hard_disk": {"capacity": 1073741824}, "ram": {"capacity": 1073741824},"testing": True}
 
         try:
             check_allocation = dendrite.query(axon, Allocate(timeline=30, device_requirement=device_requirement, checking=True,), timeout=30)

--- a/neurons/miner_checker.py
+++ b/neurons/miner_checker.py
@@ -91,7 +91,7 @@ class MinerChecker:
         allocation_status = False 
         private_key, public_key = rsa.generate_key_pair() 
 
-        device_requirement = {"cpu": {"count": 1}, "gpu": {}, "hard_disk": {"capacity": 1073741824}, "ram": {"capacity": 1073741824},"testing": True}
+        device_requirement = {"cpu": {"count": 1}, "gpu": {}, "hard_disk": {"capacity": 1073741824}, "ram": {"capacity": 1073741824}, "testing": True}
 
         try:
             check_allocation = dendrite.query(axon, Allocate(timeline=30, device_requirement=device_requirement, checking=True,), timeout=30)


### PR DESCRIPTION
This PR fixes two issues: 
1 - when an allocation is created without an SSH key it is considered a test
2 - the in-browser terminal feature for the dashboard will not work if the user didn't use their SSH key 