### PR TITLE
release/v1.8.1

### DIFF
--- a/compute/__init__.py
+++ b/compute/__init__.py
@@ -18,9 +18,9 @@
 import string
 
 # Define the version of the template module.
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 __minimal_miner_version__ = "1.8.0"
-__minimal_validator_version__ = "1.8.0"
+__minimal_validator_version__ = "1.8.1"
 
 version_split = __version__.split(".")
 __version_as_int__ = (100 * int(version_split[0])) + (10 * int(version_split[1])) + (1 * int(version_split[2]))

--- a/config.yaml
+++ b/config.yaml
@@ -71,18 +71,18 @@ gpu_performance:
     NVIDIA H100 80GB HBM3: 3.30
     NVIDIA H100: 2.80
     NVIDIA A100-SXM4-80GB: 1.90
-    NVIDIA A100 80GB PCIe: 1.65
-    NVIDIA A100-SXM4-40GB: 1.30
-    NVIDIA L40s: 0.55
-    NVIDIA RTX 6000 Ada Generation: 0.45
-    NVIDIA L40: 0.5
-    NVIDIA RTX A6000: 0.39
-    NVIDIA RTX 4090: 0.34
-    NVIDIA A40: 0.20
-    NVIDIA GeForce RTX 3090: 0.22
-    NVIDIA L4: 0.22
-    NVIDIA RTX A5000: 0.18
-    NVIDIA RTX A4500: 0.17
+    NVIDIA A100 80GB PCIe: 0
+    NVIDIA A100-SXM4-40GB: 0
+    NVIDIA L40s: 0
+    NVIDIA RTX 6000 Ada Generation: 0
+    NVIDIA L40: 0
+    NVIDIA RTX A6000: 0
+    NVIDIA RTX 4090: 0
+    NVIDIA A40: 0
+    NVIDIA GeForce RTX 3090: 0
+    NVIDIA L4: 0
+    NVIDIA RTX A5000: 0
+    NVIDIA RTX A4500: 0
 
 merkle_proof:
   miner_script_path: "neurons/Validator/miner_script_m_merkletree.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ igpu==0.1.2
 numpy==2.0.2
 psutil==5.9.8
 pyinstaller==6.4.0
-wandb==0.19.4
+wandb==0.19.0
 pyfiglet==1.0.2
 python-dotenv==1.0.1
 requests==2.31.0


### PR DESCRIPTION
 the performance values of several NVIDIA GPUs to 0, except:
- NVIDIA H200
- NVIDIA H100 80GB HBM3
- NVIDIA H100 PCIe
- NVIDIA A100-SXM4-80GB
and wandb version was downgraded to 0.19.0