### PR TITLE
chore(pre-commit): allow dev and main

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
       - id: commitlint
         stages: [commit-msg]
+        additional_dependencies: ['@commitlint/config-conventional']
 
   # Local repository for a custom hook
   - repo: local

--- a/scripts/check-branch-name.sh
+++ b/scripts/check-branch-name.sh
@@ -21,6 +21,12 @@ if [ -z "$branch_name" ] || [ "$branch_name" = "HEAD" ]; then
     exit 1
 fi
 
+# ✅ Allow dev and main branches without validation
+if echo "$branch_name" | grep -Eq "^(dev|main)$"; then
+    printf "✅ Branch '%s' is allowed and does not require validation.\n" "$branch_name"
+    exit 0
+fi
+
 # Check if it's a valid release branch (release/vX.Y.Z)
 if echo "$branch_name" | grep -Eq "^$release_version_pattern$"; then
     printf "✅ Branch name is valid (Release branch): '%s'\n" "$branch_name"


### PR DESCRIPTION
## Description
This PR addresses two issues:
1️⃣ **Adds the missing dependency** `@commitlint/config-conventional` to ensure commit message validation works correctly.  
2️⃣ **Updates the branch validation script** to allow `dev` and `main` branches without triggering errors.
