### PR TITLE
fix(setup.py): change the included packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/neuralinternet/Compute-Subnet",
     author="bittensor.com",
-    packages=find_packages(),
+    packages=find_packages(include=["compute", "neurons", "neurons.*"]),
     include_package_data=True,
     author_email="",
     license="MIT",


### PR DESCRIPTION
Replace the git subtree by changing the setup file to include both compute and neurons as a library.
It will be used for the register_api to use the compute subnet as a package library.